### PR TITLE
Add dashboard layout with event and task cards

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,10 +1,7 @@
+import Dashboard from "./pages/Dashboard";
+
 function App() {
-  return (
-    <div className="flex flex-col items-center justify-center h-screen bg-slate-900 text-white">
-      <h1 className="text-4xl font-bold mb-4">🚀 Tailwind está funcionando</h1>
-      <p className="text-lg text-slate-300">Tu entorno de Agenda Inteligente está listo.</p>
-    </div>
-  );
+  return <Dashboard />;
 }
 
 export default App;

--- a/frontend/src/components/EventCard.jsx
+++ b/frontend/src/components/EventCard.jsx
@@ -1,0 +1,17 @@
+function EventCard({ title, time, description }) {
+  return (
+    <article className="bg-white shadow-md hover:shadow-lg rounded-xl p-4 transition-transform duration-200 hover:-translate-y-0.5">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h3 className="text-lg font-semibold text-slate-900">{title}</h3>
+          <p className="text-sm text-blue-600 font-medium mt-1">{time}</p>
+        </div>
+      </div>
+      {description ? (
+        <p className="text-sm text-slate-600 mt-3 leading-relaxed">{description}</p>
+      ) : null}
+    </article>
+  );
+}
+
+export default EventCard;

--- a/frontend/src/components/TaskCard.jsx
+++ b/frontend/src/components/TaskCard.jsx
@@ -1,0 +1,9 @@
+function TaskCard({ title }) {
+  return (
+    <article className="bg-white shadow-md hover:shadow-lg rounded-xl p-4 transition-transform duration-200 hover:-translate-y-0.5">
+      <h3 className="text-base font-semibold text-slate-900">{title}</h3>
+    </article>
+  );
+}
+
+export default TaskCard;

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,0 +1,97 @@
+import EventCard from "../components/EventCard";
+import TaskCard from "../components/TaskCard";
+
+const events = [
+  {
+    id: 1,
+    title: "Reunión con equipo",
+    time: "10:00 AM",
+    description: "Revisión semanal de avances",
+  },
+  {
+    id: 2,
+    title: "Cita médica",
+    time: "3:30 PM",
+    description: "Chequeo de rutina",
+  },
+];
+
+const tasks = [
+  { id: 1, title: "Preparar presentación del proyecto" },
+  { id: 2, title: "Enviar reportes de progreso" },
+];
+
+function Dashboard() {
+  const today = new Date();
+  const formattedDate = today.toLocaleDateString("es-ES", {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+
+  const handleAddEvent = () => {
+    alert("Agregar evento");
+  };
+
+  return (
+    <div className="min-h-screen bg-slate-50 text-slate-800">
+      <header className="fixed top-0 left-0 right-0 bg-white shadow-sm z-10">
+        <div className="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
+          <h1 className="text-2xl font-semibold text-slate-900">Agenda Inteligente</h1>
+          <span className="text-sm text-slate-500 capitalize">{formattedDate}</span>
+        </div>
+      </header>
+
+      <main className="max-w-6xl mx-auto px-6 pt-28 pb-16">
+        <section className="mb-10">
+          <h2 className="text-3xl font-bold text-slate-900 mb-2">Hola, Usuario 👋</h2>
+          <p className="text-slate-600 text-base">
+            Aquí tienes un resumen de tu agenda para hoy. Mantente al día con tus
+            compromisos y tareas pendientes.
+          </p>
+        </section>
+
+        <section className="grid gap-8 lg:grid-cols-2">
+          <div>
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-xl font-semibold text-slate-900">
+                Próximos eventos
+              </h3>
+              <span className="text-sm text-slate-500">{events.length} eventos</span>
+            </div>
+            <div className="space-y-4">
+              {events.map((event) => (
+                <EventCard key={event.id} {...event} />
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-xl font-semibold text-slate-900">
+                Tareas pendientes
+              </h3>
+              <span className="text-sm text-slate-500">{tasks.length} tareas</span>
+            </div>
+            <div className="space-y-4">
+              {tasks.map((task) => (
+                <TaskCard key={task.id} {...task} />
+              ))}
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <button
+        type="button"
+        onClick={handleAddEvent}
+        className="fixed bottom-8 right-8 bg-blue-600 hover:bg-blue-700 text-white font-semibold px-6 py-3 rounded-full shadow-lg transition-transform duration-200 hover:-translate-y-0.5"
+      >
+        Agregar evento
+      </button>
+    </div>
+  );
+}
+
+export default Dashboard;


### PR DESCRIPTION
## Summary
- replace the default app shell with the new dashboard page
- add reusable EventCard and TaskCard components styled with Tailwind
- build the dashboard layout with mock events, tasks, and an add event button

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ed877e8ed88327945397c5936c8ad2