### PR TITLE
Add interactive event creation flow

### DIFF
--- a/frontend/src/components/AddEventButton.jsx
+++ b/frontend/src/components/AddEventButton.jsx
@@ -1,0 +1,15 @@
+// Botón reutilizable para disparar la creación de un nuevo evento.
+// Se mantiene la apariencia flotante utilizando clases de Tailwind.
+function AddEventButton({ onClick }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="fixed bottom-8 right-8 bg-blue-600 hover:bg-blue-700 text-white font-semibold px-6 py-3 rounded-full shadow-lg transition-transform duration-200 hover:-translate-y-0.5 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+    >
+      Agregar evento
+    </button>
+  );
+}
+
+export default AddEventButton;

--- a/frontend/src/components/AddEventModal.jsx
+++ b/frontend/src/components/AddEventModal.jsx
@@ -1,0 +1,124 @@
+import { useEffect, useState } from "react";
+
+// Modal para introducir los datos de un nuevo evento.
+// Incluye control del formulario y acciones de guardar/cancelar.
+function AddEventModal({ isOpen, onClose, onSave }) {
+  const [formValues, setFormValues] = useState({
+    title: "",
+    time: "",
+    description: "",
+  });
+
+  // Cuando el modal se abre, reiniciamos los campos para evitar datos residuales.
+  useEffect(() => {
+    if (isOpen) {
+      setFormValues({ title: "", time: "", description: "" });
+    }
+  }, [isOpen]);
+
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+    setFormValues((current) => ({ ...current, [name]: value }));
+  };
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    if (!formValues.title.trim() || !formValues.time.trim()) {
+      return;
+    }
+
+    onSave({
+      title: formValues.title.trim(),
+      time: formValues.time.trim(),
+      description: formValues.description.trim(),
+    });
+    onClose();
+  };
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-20 flex items-center justify-center bg-slate-900/50 backdrop-blur-sm px-4">
+      <div className="w-full max-w-md bg-white rounded-2xl shadow-2xl p-6">
+        <div className="mb-4">
+          <h2 className="text-xl font-semibold text-slate-900">Nuevo evento</h2>
+          <p className="text-sm text-slate-500 mt-1">
+            Completa la información para añadirlo a tu agenda.
+          </p>
+        </div>
+
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div>
+            <label htmlFor="title" className="block text-sm font-medium text-slate-700">
+              Título
+            </label>
+            <input
+              id="title"
+              name="title"
+              type="text"
+              value={formValues.title}
+              onChange={handleChange}
+              className="mt-1 block w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-2 text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+              placeholder="Ej. Reunión con marketing"
+              required
+            />
+          </div>
+
+          <div>
+            <label htmlFor="time" className="block text-sm font-medium text-slate-700">
+              Hora
+            </label>
+            <input
+              id="time"
+              name="time"
+              type="text"
+              value={formValues.time}
+              onChange={handleChange}
+              className="mt-1 block w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-2 text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+              placeholder="Ej. 4:00 PM"
+              required
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="description"
+              className="block text-sm font-medium text-slate-700"
+            >
+              Descripción
+            </label>
+            <textarea
+              id="description"
+              name="description"
+              value={formValues.description}
+              onChange={handleChange}
+              rows={3}
+              className="mt-1 block w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-2 text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+              placeholder="Notas adicionales"
+            />
+          </div>
+
+          <div className="flex justify-end gap-3 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 rounded-xl border border-slate-200 text-slate-600 hover:bg-slate-100 transition-colors"
+            >
+              Cancelar
+            </button>
+            <button
+              type="submit"
+              className="px-4 py-2 rounded-xl bg-blue-600 text-white font-semibold hover:bg-blue-700 transition-colors"
+            >
+              Guardar evento
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default AddEventModal;

--- a/frontend/src/hooks/useEvents.js
+++ b/frontend/src/hooks/useEvents.js
@@ -1,0 +1,33 @@
+import { useCallback, useState } from "react";
+
+// Hook personalizado para manejar la lista de eventos en memoria.
+// Se inicializa con algunos eventos de ejemplo y expone utilidades para añadir nuevos.
+export default function useEvents() {
+  const [events, setEvents] = useState(() => [
+    {
+      id: 1,
+      title: "Reunión con equipo",
+      time: "10:00 AM",
+      description: "Revisión semanal de avances",
+    },
+    {
+      id: 2,
+      title: "Cita médica",
+      time: "3:30 PM",
+      description: "Chequeo de rutina",
+    },
+  ]);
+
+  // Función para añadir un evento generando un identificador simple basado en la fecha actual.
+  const addEvent = useCallback((eventData) => {
+    setEvents((current) => [
+      ...current,
+      {
+        id: Date.now(),
+        ...eventData,
+      },
+    ]);
+  }, []);
+
+  return { events, addEvent };
+}

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,20 +1,9 @@
+import { useMemo, useState } from "react";
+import AddEventButton from "../components/AddEventButton";
+import AddEventModal from "../components/AddEventModal";
 import EventCard from "../components/EventCard";
 import TaskCard from "../components/TaskCard";
-
-const events = [
-  {
-    id: 1,
-    title: "Reunión con equipo",
-    time: "10:00 AM",
-    description: "Revisión semanal de avances",
-  },
-  {
-    id: 2,
-    title: "Cita médica",
-    time: "3:30 PM",
-    description: "Chequeo de rutina",
-  },
-];
+import useEvents from "../hooks/useEvents";
 
 const tasks = [
   { id: 1, title: "Preparar presentación del proyecto" },
@@ -22,16 +11,30 @@ const tasks = [
 ];
 
 function Dashboard() {
-  const today = new Date();
-  const formattedDate = today.toLocaleDateString("es-ES", {
-    weekday: "long",
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-  });
+  const { events, addEvent } = useEvents();
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
-  const handleAddEvent = () => {
-    alert("Agregar evento");
+  // Calculamos la fecha actual solo una vez durante el render del componente.
+  const formattedDate = useMemo(() => {
+    const today = new Date();
+    return today.toLocaleDateString("es-ES", {
+      weekday: "long",
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    });
+  }, []);
+
+  const handleAddEventClick = () => {
+    setIsModalOpen(true);
+  };
+
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+  };
+
+  const handleSaveEvent = (eventData) => {
+    addEvent(eventData);
   };
 
   return (
@@ -83,13 +86,13 @@ function Dashboard() {
         </section>
       </main>
 
-      <button
-        type="button"
-        onClick={handleAddEvent}
-        className="fixed bottom-8 right-8 bg-blue-600 hover:bg-blue-700 text-white font-semibold px-6 py-3 rounded-full shadow-lg transition-transform duration-200 hover:-translate-y-0.5"
-      >
-        Agregar evento
-      </button>
+      <AddEventButton onClick={handleAddEventClick} />
+
+      <AddEventModal
+        isOpen={isModalOpen}
+        onClose={handleCloseModal}
+        onSave={handleSaveEvent}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add a reusable `useEvents` hook to manage dashboard event state
- create modal and floating button components styled with Tailwind for adding events
- wire the dashboard to open the modal and append new events without a backend

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ed94ece1f883278ab66d6e5f128069