### PR TITLE
Ensure backend waits for MySQL before creating tables

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+COPY requirements.txt ./
+RUN pip install -r requirements.txt
+
+COPY . .
+
+CMD ["flask", "--app", "app", "run", "--host=0.0.0.0"]

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,24 +1,63 @@
-from flask import Flask
-from flask_sqlalchemy import SQLAlchemy
-from models import db
 import os
+import time
 
-app = Flask(__name__)
+from dotenv import load_dotenv
+from flask import Flask, current_app
+from sqlalchemy.exc import OperationalError
 
-# Configurar la conexión con MySQL
-app.config["SQLALCHEMY_DATABASE_URI"] = (
-    f"mysql+pymysql://{os.getenv('DB_USER')}:{os.getenv('DB_PASSWORD')}"
-    f"@{os.getenv('DB_HOST')}:{os.getenv('DB_PORT')}/{os.getenv('DB_NAME')}"
-)
-app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+from models import db
 
-db.init_app(app)
+load_dotenv()
 
-@app.route("/")
-def index():
-    return "✅ Backend Flask conectado correctamente a MySQL"
+
+def create_app() -> Flask:
+    """Configura y devuelve la instancia principal de Flask."""
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = (
+        f"mysql+pymysql://{os.getenv('DB_USER')}:{os.getenv('DB_PASSWORD')}"
+        f"@{os.getenv('DB_HOST')}:{os.getenv('DB_PORT')}/{os.getenv('DB_NAME')}"
+    )
+    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+
+    db.init_app(app)
+
+    @app.route("/")
+    def index():
+        return "✅ Backend Flask conectado correctamente a MySQL"
+
+    _initialise_database(app)
+
+    return app
+
+
+def _initialise_database(app: Flask) -> None:
+    """Crea las tablas de la base de datos con reintentos."""
+    max_attempts = int(os.getenv("DB_MAX_RETRIES", 5))
+    base_delay = float(os.getenv("DB_RETRY_DELAY", 2))
+
+    with app.app_context():
+        for attempt in range(1, max_attempts + 1):
+            try:
+                db.create_all()
+                current_app.logger.info("✅ Tablas creadas o ya existentes.")
+                return
+            except OperationalError as exc:
+                wait_seconds = base_delay * attempt
+                current_app.logger.warning(
+                    "Intento %s de crear las tablas fallido: %s. Reintentando en %.1f segundos...",
+                    attempt,
+                    exc,
+                    wait_seconds,
+                )
+                time.sleep(wait_seconds)
+        raise RuntimeError(
+            "No se pudieron crear las tablas después de varios intentos. "
+            "Verifica la conexión con la base de datos."
+        )
+
+
+app = create_app()
+
 
 if __name__ == "__main__":
-    with app.app_context():
-        db.create_all()  # 👈 crea todas las tablas automáticamente
-    app.run(host="0.0.0.0", port=5000, debug=True)
+    app.run(host="0.0.0.0", port=5000, debug=False)

--- a/backend/dockerfile
+++ b/backend/dockerfile
@@ -1,9 +1,0 @@
-FROM python:3.11
-
-WORKDIR /app
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
-
-COPY . .
-
-CMD ["flask", "run", "--host=0.0.0.0"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,9 @@ services:
   # 🧠 Backend Flask
   # ==========================================================
   backend:
-    build: ./backend
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
     container_name: agenda-backend
     restart: always
     env_file:
@@ -24,7 +26,6 @@ services:
     depends_on:
       db:
         condition: service_healthy
-    command: flask run --host=0.0.0.0
     volumes:
       - ./backend:/app
     networks:


### PR DESCRIPTION
## Summary
- replace the backend image build with an explicit Dockerfile that runs `flask --app app run`
- refactor the Flask application factory to load environment variables and retry `db.create_all()` until MySQL is ready
- clean up the compose configuration to reference the renamed Dockerfile and rely on the default container command

## Testing
- docker compose up --build -d *(fails: `docker` is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f07779e71c83278d73d8a31f7d9cbd