### PR TITLE
Rename user password field to ASCII-safe name

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -12,7 +12,7 @@ class Usuario(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     nombre = db.Column(db.String(100), nullable=False)
     correo = db.Column(db.String(150), unique=True, nullable=False)
-    contraseña_hash = db.Column(db.String(255), nullable=False)
+    password = db.Column(db.String(255), nullable=False)
     zona_horaria = db.Column(db.String(50), default='America/Mexico_City')
     creado_en = db.Column(db.DateTime, default=datetime.utcnow)
 


### PR DESCRIPTION
## Summary
- rename the Usuario model password column from `contraseña_hash` to `password` to avoid non-ASCII column names in MySQL
- ensure ORM attribute uses only ASCII characters to prevent encoding issues when creating tables

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f07e2bf69c8327bea7393d6c0a14fc