### PR TITLE
Fix MySQL init script bind mount path

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,19 @@ Proyecto **Agenda Inteligente**, una plataforma de gestión de tiempo y reunione
 ```bash
 git clone https://github.com/TU_USUARIO/agenda-inteligente.git
 cd agenda-inteligente
+```
+
+### Problema conocido: MySQL no levanta
+
+Si al ejecutar `docker-compose up` observas que el contenedor `agenda-db` se
+reinicia constantemente y `docker exec -it agenda-db mysql -uroot -prootpass`
+devuelve `Can't connect to local MySQL server through socket`, verifica que el
+archivo `backend/models/init_db.sql` exista y que el volumen en
+`docker-compose.yml` apunte a esa ruta. Una referencia incorrecta hace que
+Docker monte un directorio vacío en `/docker-entrypoint-initdb.d/init_db.sql`,
+provocando que el entrypoint de MySQL falle al intentar ejecutar el script de
+inicialización y el servidor nunca termine de arrancar.
+
+Con la configuración actualizada en este repositorio, el servicio debería
+arrancar correctamente y aceptar conexiones internas (`127.0.0.1`) y externas
+(`db:3306`).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,9 @@ services:
 
     # 💾 Script de inicialización (crea tablas y datos iniciales)
     volumes:
-      - ./backend/db/init_db.sql:/docker-entrypoint-initdb.d/init_db.sql
+      # El script realmente vive en backend/models/init_db.sql. Usamos la ruta correcta
+      # para evitar que Docker cree un directorio vacío que impida que MySQL arranque.
+      - ./backend/models/init_db.sql:/docker-entrypoint-initdb.d/init_db.sql:ro
 
     # 🩺 Healthcheck robusto (espera a que el servidor esté listo)
     healthcheck:


### PR DESCRIPTION
## Summary
- point the MySQL initialization volume at the actual init_db.sql location and mount it read-only
- document the previous bind mount issue and its symptoms in the README for easier troubleshooting

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f0b766507c83279c92d1a248d329f0