### PR TITLE
Add Google Calendar OAuth flow and backend events endpoint

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+"""Backend package for Agenda Inteligente."""

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -19,7 +19,10 @@ def create_app():
     db.init_app(app)
 
     from .routes import main
+    from backend.routes.google_events import google_events_bp
+
     app.register_blueprint(main)
+    app.register_blueprint(google_events_bp)
 
     with app.app_context():
         db.create_all()  # 👈 ESTA LÍNEA CREA LAS TABLAS

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,4 @@ Flask==3.0.3
 Flask-SQLAlchemy==3.1.1
 PyMySQL==1.1.1
 python-dotenv==1.0.1
+requests==2.31.0

--- a/backend/routes/__init__.py
+++ b/backend/routes/__init__.py
@@ -1,0 +1,1 @@
+# Routes package for external API integrations.

--- a/backend/routes/google_events.py
+++ b/backend/routes/google_events.py
@@ -1,0 +1,81 @@
+from datetime import datetime
+from typing import Any, Dict, List
+
+import requests
+from flask import Blueprint, jsonify, request
+
+
+google_events_bp = Blueprint("google_events", __name__, url_prefix="/api/google")
+
+
+def _normalize_event(event: Dict[str, Any]) -> Dict[str, Any]:
+    """Extrae los campos relevantes de un evento del calendario."""
+    start = event.get("start", {})
+    end = event.get("end", {})
+
+    def _extract_time(info: Dict[str, Any]) -> Any:
+        return info.get("dateTime") or info.get("date")
+
+    return {
+        "id": event.get("id"),
+        "summary": event.get("summary", "Sin título"),
+        "description": event.get("description"),
+        "start": _extract_time(start),
+        "end": _extract_time(end),
+        "location": event.get("location"),
+        "htmlLink": event.get("htmlLink"),
+    }
+
+
+@google_events_bp.route("/events", methods=["POST"])
+def fetch_google_events():
+    """Obtiene los próximos eventos del calendario primario de Google."""
+    payload = request.get_json(silent=True) or {}
+    access_token = payload.get("access_token")
+
+    if not access_token:
+        return (
+            jsonify({"error": "Falta el access_token de Google."}),
+            400,
+        )
+
+    params = {
+        "maxResults": 10,
+        "orderBy": "startTime",
+        "singleEvents": "true",
+        "timeMin": datetime.utcnow().isoformat() + "Z",
+    }
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+    }
+
+    try:
+        response = requests.get(
+            "https://www.googleapis.com/calendar/v3/calendars/primary/events",
+            params=params,
+            headers=headers,
+            timeout=10,
+        )
+    except requests.RequestException:
+        return (
+            jsonify({"error": "No se pudo conectar con Google Calendar."}),
+            502,
+        )
+
+    if response.status_code != 200:
+        try:
+            error_info = response.json()
+        except ValueError:
+            error_info = {"error": "No se pudo leer la respuesta de Google."}
+
+        error_message: Any = error_info.get("error", "No se pudo obtener los eventos.")
+        if isinstance(error_message, dict):
+            error_message = error_message.get("message", "No se pudo obtener los eventos.")
+
+        return jsonify({"error": error_message}), response.status_code
+
+    google_response = response.json()
+    items: List[Dict[str, Any]] = google_response.get("items", [])
+    events = [_normalize_event(event) for event in items]
+
+    return jsonify({"events": events}), 200

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@react-oauth/google": "^0.15.1",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   },

--- a/frontend/src/components/GoogleCalendarPage.jsx
+++ b/frontend/src/components/GoogleCalendarPage.jsx
@@ -1,0 +1,151 @@
+import { useState } from "react";
+import {
+  GoogleOAuthProvider,
+  useGoogleLogin,
+} from "@react-oauth/google";
+
+const clientId =
+  "1099030842105-m1bi5dq2l91f0i6ic4to7kmt6kdq3bpa.apps.googleusercontent.com";
+
+const fetchGoogleEvents = async (accessToken, setState) => {
+  const { setLoading, setError, setEvents } = setState;
+  setLoading(true);
+  setError(null);
+
+  try {
+    const response = await fetch("http://localhost:5000/api/google/events", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ access_token: accessToken }),
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.json().catch(() => ({}));
+      throw new Error(errorBody.error || "No se pudieron cargar los eventos.");
+    }
+
+    const data = await response.json();
+    setEvents(data.events || []);
+  } catch (err) {
+    setError(err.message);
+  } finally {
+    setLoading(false);
+  }
+};
+
+const GoogleCalendarContent = () => {
+  const [events, setEvents] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const login = useGoogleLogin({
+    scope: "https://www.googleapis.com/auth/calendar.readonly",
+    onSuccess: async (tokenResponse) => {
+      await fetchGoogleEvents(tokenResponse.access_token, {
+        setEvents,
+        setLoading,
+        setError,
+      });
+    },
+    onError: () => {
+      setError("No se pudo completar el inicio de sesión con Google.");
+    },
+    flow: "implicit",
+  });
+
+  return (
+    <div className="mx-auto flex max-w-3xl flex-col gap-6 rounded-xl bg-white/80 p-8 shadow-lg">
+      <div className="flex flex-col gap-2 text-center">
+        <h1 className="text-2xl font-semibold text-slate-900">
+          Conecta tu Google Calendar
+        </h1>
+        <p className="text-sm text-slate-600">
+          Inicia sesión con tu cuenta de Google para sincronizar tus próximos
+          eventos.
+        </p>
+      </div>
+
+      <button
+        type="button"
+        onClick={() => login()}
+        className="mx-auto flex items-center gap-2 rounded-full bg-blue-600 px-6 py-3 font-medium text-white transition hover:bg-blue-700"
+        disabled={loading}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 48 48"
+          className="h-5 w-5"
+        >
+          <path
+            fill="#4285F4"
+            d="M45.09 24.5c0-1.59-.14-3.13-.41-4.62H24v8.74h11.86c-.51 2.74-2.09 5.06-4.43 6.61v5.48h7.16c4.19-3.86 6.5-9.55 6.5-16.21z"
+          />
+          <path
+            fill="#34A853"
+            d="M24 46c5.85 0 10.77-1.94 14.36-5.29l-7.16-5.48c-2 1.32-4.56 2.1-7.2 2.1-5.53 0-10.22-3.73-11.89-8.76H4.66v5.6C8.23 40.78 15.51 46 24 46z"
+          />
+          <path
+            fill="#FBBC05"
+            d="M12.11 28.57c-.45-1.32-.71-2.72-.71-4.17 0-1.45.26-2.85.71-4.17v-5.6H4.66A21.99 21.99 0 0 0 2 24.4c0 3.54.85 6.89 2.66 9.77l7.45-5.6z"
+          />
+          <path
+            fill="#EA4335"
+            d="M24 10.66c3.18 0 6.03 1.09 8.28 3.22l6.19-6.19C34.73 3.08 29.82 1 24 1 15.51 1 8.23 6.22 4.66 13.43l7.45 5.6C13.78 14.39 18.47 10.66 24 10.66z"
+          />
+          <path fill="none" d="M2 2h44v44H2z" />
+        </svg>
+        {loading ? "Conectando..." : "Conectar con Google Calendar"}
+      </button>
+
+      {error && (
+        <div className="rounded-lg bg-red-50 p-4 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      <section className="flex flex-col gap-3">
+        <h2 className="text-lg font-semibold text-slate-900">Próximos eventos</h2>
+        {loading && (
+          <p className="text-sm text-slate-500">Cargando eventos...</p>
+        )}
+        {!loading && events.length === 0 && (
+          <p className="text-sm text-slate-500">
+            Aún no has sincronizado tus eventos de Google Calendar.
+          </p>
+        )}
+        <ul className="flex flex-col gap-3">
+          {events.map((event) => (
+            <li
+              key={event.id}
+              className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm"
+            >
+              <p className="text-base font-medium text-slate-900">
+                {event.summary}
+              </p>
+              <p className="text-sm text-slate-600">
+                {event.start ? new Date(event.start).toLocaleString() : "Sin fecha"}
+              </p>
+              {event.location && (
+                <p className="text-xs text-slate-500">{event.location}</p>
+              )}
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+};
+
+const GoogleCalendarPage = () => {
+  return (
+    <GoogleOAuthProvider clientId={clientId}>
+      <div className="min-h-screen bg-slate-100 py-12">
+        <GoogleCalendarContent />
+      </div>
+    </GoogleOAuthProvider>
+  );
+};
+
+export default GoogleCalendarPage;


### PR DESCRIPTION
## Summary
- add a React GoogleCalendarPage that authenticates with Google OAuth and renders upcoming calendar events
- create a Flask blueprint that accepts an access token and proxies the Google Calendar events API
- register the blueprint and declare the new runtime dependencies in the backend and frontend

## Testing
- npm install *(fails: 403 Forbidden when downloading @react-oauth/google)*

------
https://chatgpt.com/codex/tasks/task_e_68f5959fb2508327b0699a2966369636