### PR TITLE
Use PyMySQL to wait for database in backend entrypoint

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,4 +6,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-CMD ["flask", "run", "--host=0.0.0.0", "--port=5000"]
+RUN chmod +x /app/entrypoint.sh
+
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "⏳ Esperando a la base de datos..."
+
+python <<'PY'
+import os
+import time
+
+import pymysql
+
+host = os.getenv("DB_HOST", "db")
+user = os.getenv("DB_USER", "root")
+password = os.getenv("DB_PASSWORD", "")
+database = os.getenv("DB_NAME")
+port = int(os.getenv("DB_PORT", "3306"))
+interval = float(os.getenv("DB_RETRY_INTERVAL", "2"))
+max_wait = float(os.getenv("DB_MAX_WAIT", "60"))
+
+deadline = time.time() + max_wait
+
+while True:
+    try:
+        connection = pymysql.connect(
+            host=host,
+            user=user,
+            password=password,
+            database=database,
+            port=port,
+            connect_timeout=5,
+        )
+    except Exception as exc:  # pylint: disable=broad-except
+        print(f"❌ Aún no disponible ({exc}), reintentando...", flush=True)
+        if time.time() >= deadline:
+            raise SystemExit("⛔️ Tiempo de espera agotado esperando la base de datos.")
+        time.sleep(interval)
+    else:
+        connection.close()
+        print("✅ Base de datos disponible!", flush=True)
+        break
+PY
+
+echo "🚀 Iniciando Flask..."
+exec flask run --host=0.0.0.0 --port=5000


### PR DESCRIPTION
## Summary
- add an entrypoint script that waits for the MySQL service using PyMySQL before launching Flask
- update the backend Dockerfile to run the new entrypoint script

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f5bdf1fa8483278531d202136f658c