### PR TITLE
Fix blueprint imports and set API prefix

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -21,8 +21,8 @@ def create_app():
     db.init_app(app)
     CORS(app)
 
-    from app.routes import bp as main_bp
-    from app.routes.google_events import bp as google_bp
+    from .routes import bp as main_bp
+    from .routes.google_events import bp as google_bp
 
     app.register_blueprint(main_bp)
     app.register_blueprint(google_bp)

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -3,7 +3,7 @@ from flask import Blueprint, jsonify, request
 from ..models import Usuario
 from .. import db
 
-bp = Blueprint("main", __name__)
+bp = Blueprint("main", __name__, url_prefix="/api")
 
 
 @bp.route("/")

--- a/backend/routes/__init__.py
+++ b/backend/routes/__init__.py
@@ -1,1 +1,9 @@
-# Routes package for external API integrations.
+"""Compatibility helpers that re-export the actual blueprints."""
+
+from ..app.routes import bp as main_bp
+from ..app.routes.google_events import bp as google_bp
+
+bp = main_bp
+google_events_bp = google_bp
+
+__all__ = ["bp", "main_bp", "google_bp", "google_events_bp"]

--- a/backend/routes/google_events.py
+++ b/backend/routes/google_events.py
@@ -1,4 +1,4 @@
-from app.routes.google_events import bp as bp
+from ..app.routes.google_events import bp as bp
 
 # Alias para retrocompatibilidad con importaciones anteriores
 google_events_bp = bp


### PR DESCRIPTION
## Summary
- switch the application factory to import blueprints via package-relative paths to avoid resolving the wrong module
- ensure the main blueprint is mounted under the `/api` prefix and keep compatibility re-exports in `backend.routes`
- update compatibility wrappers to use package-relative imports as well

## Testing
- not run (MySQL service not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68f5c35f25b08327b9cee604e244869d