### PR TITLE
Ensure backend uses PyMySQL entrypoint

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,11 +1,15 @@
 FROM python:3.11-slim
 
 WORKDIR /app
+
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Copiamos el código de la aplicación (incluido entrypoint.sh)
 COPY . .
 
+# Garantizamos permisos de ejecución para el script de arranque
 RUN chmod +x /app/entrypoint.sh
 
+# PyMySQL hace la espera de la base de datos antes de lanzar Flask
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,9 @@ services:
   # 🧠 Servicio de backend Flask
   # ============================================================
   backend:
-    build: ./backend
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
     container_name: agenda-backend
     restart: always
     env_file:
@@ -46,6 +48,7 @@ services:
       - ./backend:/app
     ports:
       - "5000:5000"
+    entrypoint: ["/app/entrypoint.sh"]
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- document the backend Dockerfile steps that install dependencies, copy the app code, and enforce the executable flag on entrypoint.sh
- make docker-compose explicitly build from backend/Dockerfile and force the service to start via /app/entrypoint.sh

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f5c68572388327a8fc836328e5e75a