### PR TITLE
Improve backend startup diagnostics and db health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,21 @@ docker compose build --no-cache backend
 docker compose up -d
 ```
 
+### Flujo de arranque del backend
+Al iniciar los contenedores deberías ver, en los logs del backend, un flujo similar al siguiente:
+
+```
+⏳ Esperando a la base de datos...
+🔍 Intentando conectar a MySQL (host=db, user=agenda_user, port=3306, db=agenda_inteligente)
+  ↳ Intento 1: apertura de conexión (timeout=5s, tiempo restante ~115s)
+⚠️ MySQL aún no acepta conexiones (connection refused): (2003, "Can't connect to MySQL server on 'db' ([Errno 111] Connection refused)")
+  ↳ Intento 2: apertura de conexión (timeout=5s, tiempo restante ~113s)
+✅ Base de datos disponible, conexión de prueba cerrada.
+🚀 Iniciando Flask...
+```
+
+Los mensajes indican claramente si MySQL todavía no acepta conexiones, si hubo un problema de credenciales (`🚫 Credenciales rechazadas por MySQL`) o si se alcanzó el tiempo máximo de espera (`⛔️ Tiempo de espera agotado esperando la base de datos.`). Una vez establecida la conexión de prueba se inicia Flask y deberías ver el mensaje `Running on http://0.0.0.0:5000` en los logs.
+
 ### Endpoints
 - Backend disponible en: [http://localhost:5000](http://localhost:5000)
 - Endpoint de eventos de Google: [http://localhost:5000/api/google/events](http://localhost:5000/api/google/events)

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,44 +1,78 @@
 #!/bin/bash
 set -euo pipefail
 
-echo "⏳ Esperando a la base de datos..."
-
 python <<'PY'
+"""Script auxiliar para esperar la disponibilidad de MySQL con logs detallados."""
+
+from __future__ import annotations
+
 import os
+import sys
 import time
 
 import pymysql
+from pymysql import err as pymysql_err
+
 
 host = os.getenv("DB_HOST", "db")
 user = os.getenv("DB_USER", "root")
 password = os.getenv("DB_PASSWORD", "")
-database = os.getenv("DB_NAME")
+database = os.getenv("DB_NAME", "")
 port = int(os.getenv("DB_PORT", "3306"))
 interval = float(os.getenv("DB_RETRY_INTERVAL", "2"))
 max_wait = float(os.getenv("DB_MAX_WAIT", "60"))
 
 deadline = time.time() + max_wait
+attempt = 1
+
+print("⏳ Esperando a la base de datos...", flush=True)
+print(
+    f"🔍 Intentando conectar a MySQL (host={host}, user={user}, port={port}, db={database or '[sin definir]'})",
+    flush=True,
+)
 
 while True:
+    remaining = max(0, int(deadline - time.time()))
     try:
+        print(
+            f"  ↳ Intento {attempt}: apertura de conexión (timeout=5s, tiempo restante ~{remaining}s)",
+            flush=True,
+        )
         connection = pymysql.connect(
             host=host,
             user=user,
             password=password,
-            database=database,
+            database=database or None,
             port=port,
             connect_timeout=5,
         )
+    except pymysql_err.OperationalError as exc:
+        error_code = exc.args[0] if exc.args else None
+        if error_code == 1045:
+            message = "🚫 Credenciales rechazadas por MySQL"
+        elif error_code in {2002, 2003} or "Connection refused" in str(exc):
+            message = "⚠️ MySQL aún no acepta conexiones (connection refused)"
+        else:
+            message = "⚠️ Error operacional al conectar con MySQL"
+        print(f"{message}: {exc}", flush=True)
     except Exception as exc:  # pylint: disable=broad-except
-        print(f"❌ Aún no disponible ({exc}), reintentando...", flush=True)
-        if time.time() >= deadline:
-            raise SystemExit("⛔️ Tiempo de espera agotado esperando la base de datos.")
-        time.sleep(interval)
+        print(
+            f"⚠️ Error inesperado al conectar con MySQL: {exc.__class__.__name__}: {exc}",
+            flush=True,
+        )
     else:
         connection.close()
-        print("✅ Base de datos disponible!", flush=True)
+        print("✅ Base de datos disponible, conexión de prueba cerrada.", flush=True)
         break
+
+    if time.time() >= deadline:
+        print("⛔️ Tiempo de espera agotado esperando la base de datos.", flush=True)
+        sys.exit(1)
+
+    time.sleep(interval)
+    attempt += 1
+
+print("🚀 Iniciando Flask...", flush=True)
 PY
 
-echo "🚀 Iniciando Flask..."
 exec flask run --host=0.0.0.0 --port=5000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,11 +27,11 @@ services:
     ports:
       - "3307:3306"
     healthcheck:
-      test: ["CMD-SHELL", "mysqladmin ping -h 127.0.0.1 -prootpass --silent"]
+      test: ["CMD-SHELL", "mysqladmin ping -h localhost -prootpass --silent"]
       interval: 10s
       timeout: 5s
-      retries: 15
-      start_period: 60s
+      retries: 10
+      start_period: 30s
 
   # ============================================================
   # 🧠 Servicio de backend Flask
@@ -47,13 +47,15 @@ services:
     ports:
       - "5000:5000"
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     environment:
       DB_HOST: db
       DB_PORT: 3306
       DB_USER: agenda_user
       DB_PASSWORD: agenda123
       DB_NAME: agenda_inteligente
+      DB_MAX_WAIT: 120
 
 # ============================================================
 # 💾 Volúmenes persistentes


### PR DESCRIPTION
## Summary
- add granular MySQL connection logging and error handling to the backend entrypoint
- require the database healthcheck before starting the backend and extend the wait window
- document the expected startup log flow in the README for easier troubleshooting

## Testing
- Not run (docker is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68f5de0251648327b587fffb0ccee307