### PR TITLE
Increase MySQL healthcheck tolerance

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,10 +28,10 @@ services:
       - "3307:3306"
     healthcheck:
       test: ["CMD-SHELL", "mysqladmin ping -h localhost -prootpass --silent"]
-      interval: 10s
+      interval: 15s
       timeout: 5s
-      retries: 10
-      start_period: 30s
+      retries: 12
+      start_period: 180s
     networks:
       default:
         aliases:
@@ -60,7 +60,7 @@ services:
       DB_USER: agenda_user
       DB_PASSWORD: agenda123
       DB_NAME: agenda_inteligente
-      DB_MAX_WAIT: 120
+      DB_MAX_WAIT: 240
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:?Se requiere GOOGLE_CLIENT_ID (configúralo en .env o en el entorno de docker compose)}
       GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:?Se requiere GOOGLE_CLIENT_SECRET (configúralo en .env o en el entorno de docker compose)}
       GOOGLE_REDIRECT_URI: ${GOOGLE_REDIRECT_URI:?Se requiere GOOGLE_REDIRECT_URI (configúralo en .env o en el entorno de docker compose)}


### PR DESCRIPTION
## Summary
- extend the MySQL container healthcheck start period and retries to accommodate longer initialization times
- raise the backend database wait window to match the slower database startup

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f6ca0da9508327850ddea616a9346b