### PR TITLE
Restore Google Calendar OAuth integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# Backend
+DB_HOST=db
+DB_PORT=3306
+DB_USER=agenda_user
+DB_PASSWORD=agenda123
+DB_NAME=agenda_inteligente
+
+# Google OAuth
+GOOGLE_CLIENT_ID=tu-client-id.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=tu-client-secret
+GOOGLE_REDIRECT_URI=http://localhost:5000/api/google/callback
+FRONTEND_BASE_URL=http://localhost:5173
+
+# Frontend (Vite)
+VITE_API_BASE_URL=http://localhost:5000
+VITE_GOOGLE_CLIENT_ID=tu-client-id.apps.googleusercontent.com

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -17,6 +17,7 @@ def create_app():
         f"{os.getenv('DB_HOST')}:{os.getenv('DB_PORT')}/{os.getenv('DB_NAME')}"
     )
     app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+    app.config["FRONTEND_BASE_URL"] = os.getenv("FRONTEND_BASE_URL", "http://localhost:5173")
 
     db.init_app(app)
     CORS(app)

--- a/backend/app/routes/google_events.py
+++ b/backend/app/routes/google_events.py
@@ -1,17 +1,40 @@
-from datetime import datetime
+"""Endpoints de integración con Google Calendar."""
+
+from __future__ import annotations
+
+import json
 import os
 import traceback
-from typing import Any, Dict, List
-from urllib.parse import urlencode
+from datetime import datetime, timedelta
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+from urllib.parse import unquote, urlencode
 
 import requests
-from flask import Blueprint, jsonify, request, current_app
+from flask import Blueprint, current_app, jsonify, redirect, request
+
+from .. import db
+from ..models import CuentaConectada, EventoExterno, Usuario
 
 bp = Blueprint("google_events", __name__, url_prefix="/api/google")
+
+GOOGLE_AUTH_SCOPE = " ".join(
+    [
+        "https://www.googleapis.com/auth/calendar.readonly",
+        "https://www.googleapis.com/auth/userinfo.email",
+        "https://www.googleapis.com/auth/userinfo.profile",
+        "openid",
+    ]
+)
+GOOGLE_EVENTS_ENDPOINT = (
+    "https://www.googleapis.com/calendar/v3/calendars/primary/events"
+)
+GOOGLE_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token"
+GOOGLE_USERINFO_ENDPOINT = "https://openidconnect.googleapis.com/v1/userinfo"
 
 
 def _get_google_oauth_settings() -> Dict[str, str]:
     """Obtiene la configuración necesaria para Google OAuth desde config o env."""
+
     required_keys = (
         "GOOGLE_CLIENT_ID",
         "GOOGLE_CLIENT_SECRET",
@@ -39,20 +62,347 @@ def _get_google_oauth_settings() -> Dict[str, str]:
     return settings
 
 
+def _decode_state(value: Optional[str]) -> Dict[str, Any]:
+    if not value:
+        return {}
+
+    try:
+        decoded = unquote(value)
+        data = json.loads(decoded)
+        return data if isinstance(data, dict) else {}
+    except (ValueError, json.JSONDecodeError):
+        current_app.logger.warning("No se pudo decodificar el parámetro state enviado por Google.")
+        return {}
+
+
+def _validate_redirect(target: Optional[str]) -> Optional[str]:
+    if not target:
+        return None
+
+    allowed_base = (
+        current_app.config.get("FRONTEND_BASE_URL")
+        or os.getenv("FRONTEND_BASE_URL")
+        or "http://localhost:5173"
+    )
+
+    if not target.startswith(allowed_base):
+        current_app.logger.warning(
+            "Intento de redirección no permitido a %s. Base permitida: %s",
+            target,
+            allowed_base,
+        )
+        return None
+
+    return target
+
+
+def _build_redirect_url(target: str, params: Dict[str, Any]) -> str:
+    filtered = {k: v for k, v in params.items() if v not in (None, "")}
+    return f"{target}?{urlencode(filtered)}" if filtered else target
+
+
+def _exchange_code_for_tokens(code: str) -> Dict[str, Any]:
+    oauth_settings = _get_google_oauth_settings()
+    data = {
+        "code": code,
+        "client_id": oauth_settings["GOOGLE_CLIENT_ID"],
+        "client_secret": oauth_settings["GOOGLE_CLIENT_SECRET"],
+        "redirect_uri": oauth_settings["GOOGLE_REDIRECT_URI"],
+        "grant_type": "authorization_code",
+    }
+
+    response = requests.post(GOOGLE_TOKEN_ENDPOINT, data=data, timeout=10)
+    if response.status_code != 200:
+        error_details = response.text
+        current_app.logger.error(
+            "Error al intercambiar el código de autorización de Google: %s",
+            error_details,
+        )
+        raise RuntimeError("No se pudo completar el intercambio de tokens con Google.")
+
+    return response.json()
+
+
+def _fetch_google_user_info(access_token: str) -> Dict[str, Any]:
+    try:
+        response = requests.get(
+            GOOGLE_USERINFO_ENDPOINT,
+            headers={"Authorization": f"Bearer {access_token}"},
+            timeout=10,
+        )
+    except requests.RequestException as exc:  # pragma: no cover - errores de red
+        raise RuntimeError("No se pudo obtener la información del usuario de Google.") from exc
+
+    if response.status_code != 200:
+        current_app.logger.error(
+            "Respuesta inesperada de Google al pedir userinfo: %s",
+            response.text,
+        )
+        raise RuntimeError("No se pudo obtener la información del usuario de Google.")
+
+    userinfo = response.json()
+    if not isinstance(userinfo, dict):
+        raise RuntimeError("Google devolvió un userinfo inválido.")
+    return userinfo
+
+
+def _get_or_create_user(email: Optional[str], name: Optional[str]) -> Usuario:
+    if not email:
+        raise RuntimeError("Google no devolvió un correo electrónico válido.")
+
+    usuario = Usuario.query.filter_by(correo=email).first()
+    if usuario:
+        return usuario
+
+    usuario = Usuario(
+        nombre=name or email.split("@")[0],
+        correo=email,
+        zona_horaria="UTC",
+    )
+    db.session.add(usuario)
+    db.session.commit()
+
+    current_app.logger.info("Creado usuario %s a partir de Google OAuth", usuario.id)
+    return usuario
+
+
+def _save_tokens(
+    usuario: Usuario, tokens: Dict[str, Any], correo_vinculado: Optional[str]
+) -> CuentaConectada:
+    cuenta = CuentaConectada.query.filter_by(
+        id_usuario=usuario.id, proveedor="google"
+    ).first()
+
+    if not cuenta:
+        cuenta = CuentaConectada(
+            usuario=usuario,
+            proveedor="google",
+        )
+        db.session.add(cuenta)
+
+    expires_in = tokens.get("expires_in")
+    expiration = (
+        datetime.utcnow() + timedelta(seconds=int(expires_in))
+        if expires_in
+        else None
+    )
+
+    cuenta.correo_vinculado = correo_vinculado or usuario.correo
+    cuenta.access_token = tokens.get("access_token")
+    cuenta.token_expira_en = expiration
+    cuenta.sincronizado_en = datetime.utcnow()
+
+    refresh_token = tokens.get("refresh_token")
+    if refresh_token:
+        cuenta.refresh_token = refresh_token
+
+    db.session.commit()
+    current_app.logger.info("OAuth tokens guardados para el usuario %s", usuario.id)
+
+    return cuenta
+
+
+def _token_needs_refresh(cuenta: CuentaConectada) -> bool:
+    if not cuenta.token_expira_en:
+        return False
+    return cuenta.token_expira_en <= datetime.utcnow() + timedelta(minutes=2)
+
+
+def _refresh_access_token(cuenta: CuentaConectada) -> str:
+    if not cuenta.refresh_token:
+        raise RuntimeError("No hay refresh_token almacenado para esta cuenta.")
+
+    oauth_settings = _get_google_oauth_settings()
+    data = {
+        "client_id": oauth_settings["GOOGLE_CLIENT_ID"],
+        "client_secret": oauth_settings["GOOGLE_CLIENT_SECRET"],
+        "grant_type": "refresh_token",
+        "refresh_token": cuenta.refresh_token,
+    }
+
+    response = requests.post(GOOGLE_TOKEN_ENDPOINT, data=data, timeout=10)
+    if response.status_code != 200:
+        current_app.logger.error(
+            "Google rechazó el refresh token para la cuenta %s: %s",
+            cuenta.id,
+            response.text,
+        )
+        raise RuntimeError("No se pudo refrescar el access_token de Google.")
+
+    data = response.json()
+    cuenta.access_token = data.get("access_token")
+
+    expires_in = data.get("expires_in")
+    if expires_in:
+        cuenta.token_expira_en = datetime.utcnow() + timedelta(seconds=int(expires_in))
+
+    new_refresh = data.get("refresh_token")
+    if new_refresh:
+        cuenta.refresh_token = new_refresh
+
+    cuenta.sincronizado_en = datetime.utcnow()
+    db.session.commit()
+
+    current_app.logger.info("Token de acceso refrescado para la cuenta %s", cuenta.id)
+    return cuenta.access_token or ""
+
+
+def _parse_google_datetime(time_info: Optional[Dict[str, Any]]) -> Optional[datetime]:
+    if not time_info:
+        return None
+
+    value = time_info.get("dateTime") or time_info.get("date")
+    if not value:
+        return None
+
+    if len(value) == 10:  # Fecha sin hora
+        try:
+            return datetime.strptime(value, "%Y-%m-%d")
+        except ValueError:
+            return None
+
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def _map_event_status(status: Optional[str]) -> Optional[str]:
+    if not status:
+        return "confirmado"
+
+    mapping = {
+        "confirmed": "confirmado",
+        "cancelled": "cancelado",
+        "tentative": "tentativo",
+    }
+    return mapping.get(status.lower(), "confirmado")
+
+
+def _normalize_event(event: Dict[str, Any]) -> Dict[str, Any]:
+    start_info = event.get("start", {})
+    end_info = event.get("end", {})
+
+    def _extract_time(info: Dict[str, Any]) -> Optional[str]:
+        return info.get("dateTime") or info.get("date")
+
+    is_all_day = bool(start_info.get("date") and not start_info.get("dateTime"))
+
+    return {
+        "id": event.get("id"),
+        "summary": event.get("summary", "Sin título"),
+        "description": event.get("description"),
+        "start": _extract_time(start_info),
+        "end": _extract_time(end_info),
+        "location": event.get("location"),
+        "htmlLink": event.get("htmlLink"),
+        "status": event.get("status"),
+        "isAllDay": is_all_day,
+    }
+
+
+def _persist_events(
+    cuenta: CuentaConectada, items: Iterable[Dict[str, Any]]
+) -> None:
+    existentes: Dict[str, EventoExterno] = {
+        evento.id_evento_externo: evento for evento in cuenta.eventos
+    }
+    vistos: set[str] = set()
+
+    for item in items:
+        event_id = item.get("id")
+        if not event_id:
+            continue
+        vistos.add(event_id)
+
+        evento = existentes.get(event_id)
+        if not evento:
+            evento = EventoExterno(
+                cuenta=cuenta,
+                id_evento_externo=event_id,
+                origen="google",
+            )
+            db.session.add(evento)
+
+        evento.titulo = item.get("summary", "Sin título")
+        evento.descripcion = item.get("description")
+        evento.inicio = _parse_google_datetime(item.get("start"))
+        evento.fin = _parse_google_datetime(item.get("end"))
+        evento.estado = _map_event_status(item.get("status"))
+        evento.sincronizado_en = datetime.utcnow()
+
+    for event_id, evento in existentes.items():
+        if event_id not in vistos:
+            db.session.delete(evento)
+
+    cuenta.sincronizado_en = datetime.utcnow()
+    db.session.commit()
+
+
+def _call_google_events(access_token: str) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    params = {
+        "maxResults": 15,
+        "orderBy": "startTime",
+        "singleEvents": "true",
+        "timeMin": datetime.utcnow().isoformat() + "Z",
+    }
+    headers = {"Authorization": f"Bearer {access_token}"}
+
+    try:
+        response = requests.get(
+            GOOGLE_EVENTS_ENDPOINT,
+            params=params,
+            headers=headers,
+            timeout=10,
+        )
+    except requests.RequestException as exc:  # pragma: no cover - errores de red
+        raise RuntimeError("No se pudo conectar con Google Calendar.") from exc
+
+    if response.status_code != 200:
+        try:
+            error_info = response.json()
+        except ValueError:  # pragma: no cover - cuerpo inesperado
+            error_info = {"error": response.text}
+
+        error_message = error_info.get("error", {})
+        if isinstance(error_message, dict):
+            error_message = error_message.get("message")
+
+        raise RuntimeError(error_message or "No se pudieron obtener los eventos de Google.")
+
+    payload = response.json()
+    items: List[Dict[str, Any]] = payload.get("items", [])
+    normalized = [_normalize_event(event) for event in items]
+    return items, normalized
+
+
+def _fetch_events_for_account(cuenta: CuentaConectada) -> List[Dict[str, Any]]:
+    if _token_needs_refresh(cuenta):
+        _refresh_access_token(cuenta)
+
+    access_token = cuenta.access_token
+    if not access_token:
+        raise RuntimeError("No hay un access_token válido para esta cuenta.")
+
+    items, normalized = _call_google_events(access_token)
+    _persist_events(cuenta, items)
+    return normalized
+
+
 @bp.route("/auth", methods=["GET"])
 def initialize_google_oauth():
     """Devuelve la URL de autorización de Google OAuth."""
+
     try:
         oauth_settings = _get_google_oauth_settings()
         client_id = oauth_settings["GOOGLE_CLIENT_ID"]
-        _ = oauth_settings["GOOGLE_CLIENT_SECRET"]  # Solo validamos su presencia.
         redirect_uri = oauth_settings["GOOGLE_REDIRECT_URI"]
 
-        scope = request.args.get(
-            "scope",
-            "https://www.googleapis.com/auth/calendar.readonly",
-        )
         state = request.args.get("state")
+        scope = request.args.get("scope", GOOGLE_AUTH_SCOPE)
 
         query_params = {
             "response_type": "code",
@@ -66,10 +416,7 @@ def initialize_google_oauth():
         if state:
             query_params["state"] = state
 
-        auth_url = (
-            "https://accounts.google.com/o/oauth2/v2/auth?" + urlencode(query_params)
-        )
-
+        auth_url = "https://accounts.google.com/o/oauth2/v2/auth?" + urlencode(query_params)
         current_app.logger.info(
             "Generada URL de OAuth de Google con redirect_uri=%s", redirect_uri
         )
@@ -79,7 +426,6 @@ def initialize_google_oauth():
         error_message = f"Error al iniciar OAuth de Google: {exc}"
         traceback_str = traceback.format_exc()
         current_app.logger.error("%s\n%s", error_message, traceback_str)
-        print(error_message, traceback_str, sep="\n", flush=True)
         return (
             jsonify({
                 "error": "OAuth init failed",
@@ -89,77 +435,154 @@ def initialize_google_oauth():
         )
 
 
-def _normalize_event(event: Dict[str, Any]) -> Dict[str, Any]:
-    """Extrae los campos relevantes de un evento del calendario."""
-    start = event.get("start", {})
-    end = event.get("end", {})
+@bp.route("/callback", methods=["GET", "POST"])
+def google_oauth_callback():
+    """Recibe el código de Google, guarda tokens y sincroniza eventos."""
 
-    def _extract_time(info: Dict[str, Any]) -> Any:
-        return info.get("dateTime") or info.get("date")
+    payload = request.get_json(silent=True) or {} if request.method == "POST" else {}
+    code = payload.get("code") if request.method == "POST" else request.args.get("code")
+    state = payload.get("state") if request.method == "POST" else request.args.get("state")
 
-    return {
-        "id": event.get("id"),
-        "summary": event.get("summary", "Sin título"),
-        "description": event.get("description"),
-        "start": _extract_time(start),
-        "end": _extract_time(end),
-        "location": event.get("location"),
-        "htmlLink": event.get("htmlLink"),
-    }
+    state_data = _decode_state(state)
 
-
-@bp.route("/events", methods=["POST"])
-def fetch_google_events():
-    """Obtiene los próximos eventos del calendario primario de Google."""
-    payload = request.get_json(silent=True) or {}
-    access_token = payload.get("access_token")
-
-    if not access_token:
-        return (
-            jsonify({"error": "Falta el access_token de Google."}),
-            400,
-        )
-
-    params = {
-        "maxResults": 10,
-        "orderBy": "startTime",
-        "singleEvents": "true",
-        "timeMin": datetime.utcnow().isoformat() + "Z",
-    }
-    headers = {
-        "Authorization": f"Bearer {access_token}",
-    }
+    if not code:
+        message = "Google no devolvió el parámetro 'code'."
+        if request.method == "GET":
+            redirect_target = _validate_redirect(state_data.get("redirect"))
+            if redirect_target:
+                return redirect(
+                    _build_redirect_url(
+                        redirect_target,
+                        {
+                            "status": "error",
+                            "message": message,
+                            "next": state_data.get("next"),
+                        },
+                    )
+                )
+        return jsonify({"error": message}), 400
 
     try:
-        response = requests.get(
-            "https://www.googleapis.com/calendar/v3/calendars/primary/events",
-            params=params,
-            headers=headers,
-            timeout=10,
+        tokens = _exchange_code_for_tokens(code)
+        access_token = tokens.get("access_token")
+        if not access_token:
+            raise RuntimeError("Google no devolvió un access_token válido.")
+
+        userinfo = _fetch_google_user_info(access_token)
+        usuario = _get_or_create_user(
+            email=userinfo.get("email"), name=userinfo.get("name")
         )
-    except requests.RequestException:
+        cuenta = _save_tokens(usuario, tokens, userinfo.get("email"))
+        events = _fetch_events_for_account(cuenta)
+
+        response_body = {
+            "message": "Cuenta de Google conectada exitosamente.",
+            "usuario": {
+                "id": usuario.id,
+                "nombre": usuario.nombre,
+                "correo": usuario.correo,
+            },
+            "events": events,
+        }
+
+        redirect_target = _validate_redirect(state_data.get("redirect"))
+        if request.method == "GET" and redirect_target:
+            return redirect(
+                _build_redirect_url(
+                    redirect_target,
+                    {
+                        "status": "success",
+                        "user_id": usuario.id,
+                        "email": usuario.correo,
+                        "name": usuario.nombre,
+                        "next": state_data.get("next"),
+                    },
+                )
+            )
+
+        return jsonify(response_body), 200
+    except Exception as exc:  # pylint: disable=broad-except
+        traceback_str = traceback.format_exc()
+        current_app.logger.error(
+            "Error durante el callback de Google OAuth: %s\n%s", exc, traceback_str
+        )
+
+        if request.method == "GET":
+            redirect_target = _validate_redirect(state_data.get("redirect"))
+            if redirect_target:
+                return redirect(
+                    _build_redirect_url(
+                        redirect_target,
+                        {
+                            "status": "error",
+                            "message": str(exc),
+                            "next": state_data.get("next"),
+                        },
+                    )
+                )
+
         return (
-            jsonify({"error": "No se pudo conectar con Google Calendar."}),
-            502,
+            jsonify({
+                "error": "Google OAuth callback failed",
+                "details": str(exc),
+            }),
+            500,
         )
 
-    if response.status_code != 200:
+
+@bp.route("/events", methods=["GET", "POST"])
+def fetch_google_events():
+    """Obtiene los próximos eventos del calendario primario de Google."""
+
+    if request.method == "POST":
+        payload = request.get_json(silent=True) or {}
+        user_id = payload.get("user_id")
+        email = payload.get("email")
+        access_token = payload.get("access_token")
+    else:
+        user_id = request.args.get("user_id", type=int)
+        email = request.args.get("email")
+        access_token = request.args.get("access_token")
+
+    if access_token:
         try:
-            error_info = response.json()
-        except ValueError:
-            error_info = {"error": "No se pudo leer la respuesta de Google."}
+            _, normalized = _call_google_events(access_token)
+            return jsonify({"events": normalized}), 200
+        except Exception as exc:  # pylint: disable=broad-except
+            return jsonify({"error": str(exc)}), 400
 
-        error_message: Any = error_info.get("error", "No se pudo obtener los eventos.")
-        if isinstance(error_message, dict):
-            error_message = error_message.get("message", "No se pudo obtener los eventos.")
+    cuenta = None
+    if user_id:
+        cuenta = CuentaConectada.query.filter_by(
+            id_usuario=user_id, proveedor="google"
+        ).first()
+    elif email:
+        cuenta = (
+            CuentaConectada.query.join(Usuario)
+            .filter(Usuario.correo == email, CuentaConectada.proveedor == "google")
+            .first()
+        )
 
-        return jsonify({"error": error_message}), response.status_code
+    if not cuenta:
+        return jsonify({"events": [], "requires_auth": True}), 200
 
-    google_response = response.json()
-    items: List[Dict[str, Any]] = google_response.get("items", [])
-    events = [_normalize_event(event) for event in items]
-
-    return jsonify({"events": events}), 200
+    try:
+        events = _fetch_events_for_account(cuenta)
+        return jsonify({"events": events}), 200
+    except Exception as exc:  # pylint: disable=broad-except
+        traceback_str = traceback.format_exc()
+        current_app.logger.error(
+            "No se pudieron sincronizar los eventos de Google: %s\n%s",
+            exc,
+            traceback_str,
+        )
+        return (
+            jsonify({
+                "error": "No se pudieron sincronizar los eventos de Google.",
+                "details": str(exc),
+            }),
+            500,
+        )
 
 
 __all__ = ["bp"]

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,7 +1,27 @@
+import { GoogleOAuthProvider } from "@react-oauth/google";
 import Dashboard from "./pages/Dashboard";
+import GoogleCallbackPage from "./pages/GoogleCallbackPage";
+import { GOOGLE_CLIENT_ID } from "./config";
 
 function App() {
-  return <Dashboard />;
+  const pathname = window.location.pathname;
+  const showCallback = pathname.startsWith("/google/callback");
+  const content = showCallback ? <GoogleCallbackPage /> : <Dashboard />;
+
+  if (!GOOGLE_CLIENT_ID) {
+    if (import.meta.env.DEV) {
+      console.warn(
+        "VITE_GOOGLE_CLIENT_ID no está configurado. El flujo de OAuth utilizará únicamente el backend."
+      );
+    }
+    return content;
+  }
+
+  return (
+    <GoogleOAuthProvider clientId={GOOGLE_CLIENT_ID}>
+      {content}
+    </GoogleOAuthProvider>
+  );
 }
 
 export default App;

--- a/frontend/src/components/GoogleCalendarPage.jsx
+++ b/frontend/src/components/GoogleCalendarPage.jsx
@@ -4,8 +4,7 @@ import {
   useGoogleLogin,
 } from "@react-oauth/google";
 
-const clientId =
-  "1099030842105-m1bi5dq2l91f0i6ic4to7kmt6kdq3bpa.apps.googleusercontent.com";
+import { GOOGLE_CLIENT_ID } from "../config";
 
 const fetchGoogleEvents = async (accessToken, setState) => {
   const { setLoading, setError, setEvents } = setState;
@@ -139,8 +138,20 @@ const GoogleCalendarContent = () => {
 };
 
 const GoogleCalendarPage = () => {
+  if (!GOOGLE_CLIENT_ID) {
+    return (
+      <div className="min-h-screen bg-slate-100 py-12">
+        <div className="mx-auto max-w-xl rounded-xl bg-white p-8 text-center shadow">
+          <p className="text-sm text-slate-600">
+            Configura <code>VITE_GOOGLE_CLIENT_ID</code> para habilitar esta vista.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
   return (
-    <GoogleOAuthProvider clientId={clientId}>
+    <GoogleOAuthProvider clientId={GOOGLE_CLIENT_ID}>
       <div className="min-h-screen bg-slate-100 py-12">
         <GoogleCalendarContent />
       </div>

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,0 +1,4 @@
+export const API_BASE_URL =
+  import.meta.env.VITE_API_BASE_URL ?? "http://localhost:5000";
+
+export const GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID ?? "";

--- a/frontend/src/hooks/useEvents.js
+++ b/frontend/src/hooks/useEvents.js
@@ -1,9 +1,9 @@
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 // Hook personalizado para manejar la lista de eventos en memoria.
 // Se inicializa con algunos eventos de ejemplo y expone utilidades para añadir nuevos.
 export default function useEvents() {
-  const [events, setEvents] = useState(() => [
+  const [localEvents, setLocalEvents] = useState(() => [
     {
       id: 1,
       title: "Reunión con equipo",
@@ -17,10 +17,11 @@ export default function useEvents() {
       description: "Chequeo de rutina",
     },
   ]);
+  const [externalEvents, setExternalEvents] = useState([]);
 
   // Función para añadir un evento generando un identificador simple basado en la fecha actual.
   const addEvent = useCallback((eventData) => {
-    setEvents((current) => [
+    setLocalEvents((current) => [
       ...current,
       {
         id: Date.now(),
@@ -29,5 +30,14 @@ export default function useEvents() {
     ]);
   }, []);
 
-  return { events, addEvent };
+  const events = useMemo(
+    () => [...externalEvents, ...localEvents],
+    [externalEvents, localEvents],
+  );
+
+  const replaceExternalEvents = useCallback((newEvents) => {
+    setExternalEvents(newEvents);
+  }, []);
+
+  return { events, addEvent, setExternalEvents: replaceExternalEvents };
 }

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,18 +1,77 @@
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import AddEventButton from "../components/AddEventButton";
 import AddEventModal from "../components/AddEventModal";
 import EventCard from "../components/EventCard";
 import TaskCard from "../components/TaskCard";
 import useEvents from "../hooks/useEvents";
+import { API_BASE_URL } from "../config";
 
 const tasks = [
   { id: 1, title: "Preparar presentación del proyecto" },
   { id: 2, title: "Enviar reportes de progreso" },
 ];
 
+const parseGoogleDate = (value) => {
+  if (!value) return null;
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    const [year, month, day] = value.split("-").map(Number);
+    return new Date(year, month - 1, day);
+  }
+
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+};
+
+const formatGoogleEventTime = (event) => {
+  const start = parseGoogleDate(event.start);
+  const end = parseGoogleDate(event.end);
+  if (!start) return "Sin horario";
+
+  const dateFormatter = new Intl.DateTimeFormat("es-ES", { dateStyle: "medium" });
+  const timeFormatter = new Intl.DateTimeFormat("es-ES", { timeStyle: "short" });
+
+  if (event.isAllDay) {
+    return dateFormatter.format(start);
+  }
+
+  if (!end) {
+    return `${dateFormatter.format(start)} · ${timeFormatter.format(start)}`;
+  }
+
+  const sameDay = start.toDateString() === end.toDateString();
+  if (sameDay) {
+    return `${dateFormatter.format(start)} · ${timeFormatter.format(start)} - ${timeFormatter.format(end)}`;
+  }
+
+  return `${dateFormatter.format(start)} · ${timeFormatter.format(start)} → ${dateFormatter.format(end)} · ${timeFormatter.format(end)}`;
+};
+
+const mapGoogleEventsToCards = (events) =>
+  events.map((event) => ({
+    id: `google-${event.id}`,
+    title: event.summary ?? "Sin título",
+    time: formatGoogleEventTime(event),
+    description: event.description ?? "",
+  }));
+
 function Dashboard() {
-  const { events, addEvent } = useEvents();
+  const { events, addEvent, setExternalEvents } = useEvents();
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [googleUser, setGoogleUser] = useState(() => {
+    try {
+      const stored = localStorage.getItem("agenda-google-user");
+      return stored ? JSON.parse(stored) : null;
+    } catch (error) {
+      console.error("No se pudo leer el usuario de Google almacenado", error);
+      return null;
+    }
+  });
+  const [googleState, setGoogleState] = useState({
+    connected: Boolean(googleUser),
+    connecting: false,
+    syncing: false,
+    error: null,
+  });
 
   // Calculamos la fecha actual solo una vez durante el render del componente.
   const formattedDate = useMemo(() => {
@@ -36,6 +95,86 @@ function Dashboard() {
   const handleSaveEvent = (eventData) => {
     addEvent(eventData);
   };
+
+  const fetchGoogleEvents = useCallback(async () => {
+    if (!googleUser?.id) {
+      return;
+    }
+
+    setGoogleState((prev) => ({ ...prev, syncing: true, error: null }));
+
+    try {
+      const response = await fetch(`${API_BASE_URL}/api/google/events`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ user_id: googleUser.id }),
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.json().catch(() => ({}));
+        throw new Error(
+          errorBody.error || "No se pudieron obtener los eventos de Google."
+        );
+      }
+
+      const data = await response.json();
+      if (data.requires_auth) {
+        localStorage.removeItem("agenda-google-user");
+        setGoogleUser(null);
+        setExternalEvents([]);
+        throw new Error("La sesión de Google expiró. Vuelve a conectar tu cuenta.");
+      }
+
+      const cards = mapGoogleEventsToCards(data.events ?? []);
+      setExternalEvents(cards);
+      setGoogleState((prev) => ({ ...prev, connected: true }));
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      setGoogleState((prev) => ({ ...prev, error: errorMessage, connected: false }));
+    } finally {
+      setGoogleState((prev) => ({ ...prev, syncing: false, connecting: false }));
+    }
+  }, [googleUser?.id, setExternalEvents]);
+
+  useEffect(() => {
+    if (googleUser?.id) {
+      fetchGoogleEvents();
+    }
+  }, [fetchGoogleEvents, googleUser?.id]);
+
+  const handleGoogleButtonClick = useCallback(async () => {
+    if (googleState.connected) {
+      fetchGoogleEvents();
+      return;
+    }
+
+    setGoogleState((prev) => ({ ...prev, connecting: true, error: null }));
+
+    try {
+      const statePayload = JSON.stringify({
+        redirect: `${window.location.origin}/google/callback`,
+        userId: googleUser?.id ?? null,
+        next: window.location.pathname,
+      });
+
+      const response = await fetch(
+        `${API_BASE_URL}/api/google/auth?state=${encodeURIComponent(statePayload)}`,
+      );
+
+      if (!response.ok) {
+        const errorBody = await response.json().catch(() => ({}));
+        throw new Error(errorBody.error || "No se pudo iniciar la conexión con Google.");
+      }
+
+      const data = await response.json();
+      window.location.href = data.auth_url;
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      setGoogleState((prev) => ({ ...prev, error: errorMessage, connecting: false }));
+    }
+  }, [fetchGoogleEvents, googleState.connected, googleUser?.id]);
 
   return (
     <div className="min-h-screen bg-slate-50 text-slate-800">
@@ -63,10 +202,53 @@ function Dashboard() {
               </h3>
               <span className="text-sm text-slate-500">{events.length} eventos</span>
             </div>
+            <div className="mb-4 flex flex-wrap items-center gap-3">
+              <button
+                type="button"
+                onClick={handleGoogleButtonClick}
+                disabled={googleState.connecting || googleState.syncing}
+                className="flex items-center gap-2 rounded-full bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-70"
+              >
+                {googleState.connected
+                  ? googleState.syncing
+                    ? "Sincronizando eventos..."
+                    : "Actualizar eventos de Google"
+                  : googleState.connecting
+                    ? "Redirigiendo a Google..."
+                    : "Conectar con Google Calendar"}
+              </button>
+              {googleState.connected && !googleState.syncing ? (
+                <span className="flex items-center gap-2 text-sm text-green-600">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                    className="h-4 w-4"
+                  >
+                    <path
+                      fillRule="evenodd"
+                      d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm13.36-2.59a.75.75 0 1 0-1.22-.92l-3.483 4.62-1.79-1.79a.75.75 0 0 0-1.06 1.06l2.5 2.5a.75.75 0 0 0 1.14-.094l3.913-5.376Z"
+                      clipRule="evenodd"
+                    />
+                  </svg>
+                  Sincronizado con Google Calendar
+                </span>
+              ) : null}
+            </div>
+            {googleState.error ? (
+              <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+                {googleState.error}
+              </div>
+            ) : null}
             <div className="space-y-4">
-              {events.map((event) => (
-                <EventCard key={event.id} {...event} />
-              ))}
+              {events.length === 0 ? (
+                <p className="rounded-lg border border-slate-200 bg-white p-4 text-sm text-slate-500 shadow-sm">
+                  No hay eventos programados aún. ¡Conecta tu Google Calendar o agrega
+                  uno nuevo!
+                </p>
+              ) : (
+                events.map((event) => <EventCard key={event.id} {...event} />)
+              )}
             </div>
           </div>
 

--- a/frontend/src/pages/GoogleCallbackPage.jsx
+++ b/frontend/src/pages/GoogleCallbackPage.jsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from "react";
+
+const DEFAULT_REDIRECT = "/";
+
+function GoogleCallbackPage() {
+  const [message, setMessage] = useState("Procesando la conexión con Google...");
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const status = params.get("status");
+    const userId = params.get("user_id");
+    const email = params.get("email");
+    const name = params.get("name");
+    const next = params.get("next") || DEFAULT_REDIRECT;
+
+    if (status !== "success" || !userId) {
+      const errorMessage =
+        params.get("message") || "No se pudo completar la conexión con Google.";
+      setMessage(errorMessage);
+      return;
+    }
+
+    const userData = {
+      id: Number(userId),
+      correo: email ?? "",
+      nombre: name ?? "",
+    };
+
+    localStorage.setItem("agenda-google-user", JSON.stringify(userData));
+    setMessage("Google Calendar conectado. Redirigiendo...");
+
+    const timer = setTimeout(() => {
+      window.location.replace(next);
+    }, 1200);
+
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-slate-100 px-4">
+      <div className="max-w-md rounded-lg bg-white p-8 text-center shadow">
+        <p className="text-base text-slate-700">{message}</p>
+      </div>
+    </div>
+  );
+}
+
+export default GoogleCallbackPage;


### PR DESCRIPTION
## Summary
- rebuild the Google OAuth endpoints to exchange codes, persist tokens, refresh access, and sync calendar events into MySQL
- surface Google calendar connectivity in the dashboard with a callback page, merged event list, and reusable config values
- document required backend/frontend environment variables for Google authentication

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f6cb3ab64c8327a369eec45a76f426