### PR TITLE
Create Agenda Inteligente dashboard layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@
 
 # Local data folder
 /data/
+# Node dependencies
+node_modules/
+frontend/node_modules/
+frontend/.next/

--- a/frontend/app/api/mock-events/route.ts
+++ b/frontend/app/api/mock-events/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+
+const mockEvents = [
+  {
+    id: 1,
+    time: "09:00",
+    title: "Llamada con cliente",
+    description: "Revisión de requisitos y próximos pasos",
+  },
+  {
+    id: 2,
+    time: "11:00",
+    title: "Revisión de proyecto",
+    description: "Evaluación del sprint y métricas clave",
+  },
+  {
+    id: 3,
+    time: "14:00",
+    title: "Reunión con equipo",
+    description: "Definición de prioridades para la semana",
+  },
+];
+
+export async function GET() {
+  return NextResponse.json({ events: mockEvents });
+}

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -1,0 +1,76 @@
+import Calendar from "../../components/Calendar";
+import EventCard from "../../components/EventCard";
+import LoadingSpinner from "../../components/LoadingSpinner";
+
+const teamEvents = [
+  {
+    time: "08:30",
+    title: "Daily Standup",
+    icon: "📈",
+    description: "Actualización rápida con todo el equipo de producto",
+    tag: "Daily",
+  },
+  {
+    time: "10:00",
+    title: "Diseño UX",
+    icon: "🎨",
+    location: "Sala de innovación",
+    description: "Revisión de wireframes para la nueva vista de tareas",
+  },
+  {
+    time: "16:00",
+    title: "Onboarding clientes",
+    icon: "🚀",
+    description: "Sesión de formación para nuevos clientes corporativos",
+    tag: "Clientes",
+  },
+];
+
+export default function DashboardPage() {
+  return (
+    <div className="space-y-8">
+      <section>
+        <h2 className="text-3xl font-semibold text-gray-900">Agenda detallada</h2>
+        <p className="mt-1 text-sm text-gray-500">
+          Visualiza tus reuniones, asigna tareas y gestiona recordatorios desde una misma vista.
+        </p>
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)]">
+        <div className="space-y-4">
+          <div className="rounded-2xl bg-white p-6 shadow-sm">
+            <div className="flex items-center justify-between">
+              <h3 className="text-lg font-semibold text-gray-900">Eventos del día</h3>
+              <span className="text-xs font-semibold uppercase tracking-wide text-indigo-500">
+                12 eventos programados
+              </span>
+            </div>
+            <div className="mt-6 space-y-4">
+              {teamEvents.map((event) => (
+                <EventCard key={event.title} {...event} />
+              ))}
+            </div>
+          </div>
+          <div className="rounded-2xl border border-dashed border-indigo-200 bg-indigo-50/50 p-8 text-center text-sm text-indigo-700">
+            <p className="font-semibold">Sincroniza nuevas fuentes</p>
+            <p className="mt-1 text-indigo-600">
+              Conecta otras aplicaciones para importar automáticamente tus tareas y reuniones.
+            </p>
+          </div>
+        </div>
+        <div className="space-y-6">
+          <Calendar />
+          <div className="rounded-2xl bg-white p-6 text-center shadow-sm">
+            <p className="text-sm font-semibold text-gray-900">Seguimiento de cargas</p>
+            <p className="mt-1 text-sm text-gray-500">
+              Procesando sincronización con Google Calendar...
+            </p>
+            <div className="mt-6 flex justify-center">
+              <LoadingSpinner />
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,0 +1,34 @@
+import type { Metadata } from "next";
+import { Inter } from "next/font/google";
+import type { ReactNode } from "react";
+import Header from "../components/Header";
+import Sidebar from "../components/Sidebar";
+import "../styles/globals.css";
+import "../styles/theme.css";
+
+const inter = Inter({ subsets: ["latin"], display: "swap" });
+
+export const metadata: Metadata = {
+  title: "Agenda Inteligente",
+  description: "Dashboard principal de Agenda Inteligente",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return (
+    <html lang="es">
+      <body className={`${inter.className} bg-gray-50 text-gray-900`}>
+        <div className="flex min-h-screen w-full bg-gray-50">
+          <Sidebar />
+          <div className="flex min-h-screen flex-1 flex-col md:ml-64">
+            <Header />
+            <main className="flex-1 px-4 py-6 sm:px-6 lg:px-10">{children}</main>
+          </div>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,0 +1,104 @@
+import Calendar from "../components/Calendar";
+import EventCard from "../components/EventCard";
+
+const upcomingEvents = [
+  {
+    time: "09:00",
+    title: "Llamada con cliente",
+    icon: "📞",
+    description: "Revisión de requisitos y próximos pasos",
+    tag: "Ventas",
+  },
+  {
+    time: "11:00",
+    title: "Revisión de proyecto",
+    icon: "🗂️",
+    location: "Sala 3B",
+    description: "Evaluación del sprint y métricas clave",
+  },
+  {
+    time: "14:00",
+    title: "Reunión con equipo",
+    icon: "🤝",
+    description: "Definición de prioridades para la semana",
+    tag: "Equipo",
+  },
+];
+
+const summaryCards = [
+  {
+    title: "Eventos hoy",
+    value: "8",
+    description: "+2 respecto a ayer",
+    accent: "bg-indigo-100 text-indigo-600",
+    icon: "📅",
+  },
+  {
+    title: "Próximo evento",
+    value: "Llamada con cliente",
+    description: "En 1 hora",
+    accent: "bg-emerald-100 text-emerald-600",
+    icon: "⏰",
+  },
+  {
+    title: "Tiempo libre",
+    value: "3h 20m",
+    description: "Perfecto para focus",
+    accent: "bg-amber-100 text-amber-600",
+    icon: "🧘",
+  },
+  {
+    title: "Cuentas conectadas",
+    value: "4",
+    description: "Google, Slack, Zoom, Notion",
+    accent: "bg-sky-100 text-sky-600",
+    icon: "🔗",
+  },
+];
+
+export default function HomePage() {
+  return (
+    <div className="space-y-8">
+      <section className="flex flex-col gap-2">
+        <p className="text-sm font-medium text-gray-500">Bienvenido,</p>
+        <h2 className="text-3xl font-semibold text-gray-900">Bienvenido, Daniela 👋</h2>
+        <p className="text-sm text-gray-500">
+          Gestiona tu agenda diaria, coordina con tu equipo y mantén el control de tus compromisos.
+        </p>
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        {summaryCards.map((card) => (
+          <div key={card.title} className="rounded-2xl bg-white p-5 shadow-sm">
+            <div className={`mb-3 inline-flex h-12 w-12 items-center justify-center rounded-2xl text-2xl ${card.accent}`}>
+              {card.icon}
+            </div>
+            <p className="text-sm font-medium text-gray-500">{card.title}</p>
+            <p className="mt-1 text-xl font-semibold text-gray-900">{card.value}</p>
+            <p className="mt-2 text-sm text-gray-400">{card.description}</p>
+          </div>
+        ))}
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-[minmax(0,1.15fr)_minmax(0,1fr)]">
+        <div className="space-y-4">
+          <header className="flex items-center justify-between">
+            <div>
+              <h3 className="text-xl font-semibold text-gray-900">Próximos eventos</h3>
+              <p className="text-sm text-gray-500">Mantente al día con lo que viene a continuación</p>
+            </div>
+            <button className="text-sm font-semibold text-indigo-600 hover:text-indigo-500">Ver agenda completa</button>
+          </header>
+          <div className="space-y-4">
+            {upcomingEvents.map((event) => (
+              <EventCard key={event.title} {...event} />
+            ))}
+          </div>
+        </div>
+        <div>
+          <Calendar />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -1,0 +1,82 @@
+export default function SettingsPage() {
+  return (
+    <div className="space-y-8">
+      <section>
+        <h2 className="text-3xl font-semibold text-gray-900">Configuración de cuenta</h2>
+        <p className="mt-2 text-sm text-gray-500">
+          Personaliza las notificaciones, gestiona tus integraciones y mantén tu información actualizada.
+        </p>
+      </section>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <form className="space-y-5 rounded-2xl bg-white p-6 shadow-sm">
+          <div>
+            <label htmlFor="name" className="text-sm font-semibold text-gray-700">
+              Nombre completo
+            </label>
+            <input
+              id="name"
+              name="name"
+              type="text"
+              defaultValue="Daniela García"
+              className="mt-2 w-full rounded-xl border border-gray-200 bg-gray-50 px-4 py-2.5 text-sm text-gray-700 focus:border-indigo-500 focus:bg-white focus:outline-none"
+            />
+          </div>
+          <div>
+            <label htmlFor="email" className="text-sm font-semibold text-gray-700">
+              Correo electrónico
+            </label>
+            <input
+              id="email"
+              name="email"
+              type="email"
+              defaultValue="daniela@agendainteligente.com"
+              className="mt-2 w-full rounded-xl border border-gray-200 bg-gray-50 px-4 py-2.5 text-sm text-gray-700 focus:border-indigo-500 focus:bg-white focus:outline-none"
+            />
+          </div>
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm font-semibold text-gray-700">Autenticación en dos pasos</p>
+              <p className="text-xs text-gray-500">Añade una capa adicional de seguridad a tu cuenta.</p>
+            </div>
+            <button className="rounded-full border border-gray-200 px-4 py-2 text-xs font-semibold text-gray-600 transition hover:border-indigo-200 hover:text-indigo-600">
+              Configurar
+            </button>
+          </div>
+          <button className="w-full rounded-full bg-indigo-600 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500">
+            Guardar cambios
+          </button>
+        </form>
+        <div className="space-y-5 rounded-2xl bg-white p-6 shadow-sm">
+          <div>
+            <h3 className="text-lg font-semibold text-gray-900">Notificaciones</h3>
+            <p className="text-sm text-gray-500">Controla qué alertas recibes y por qué canal.</p>
+          </div>
+          <ul className="space-y-4 text-sm text-gray-600">
+            <li className="flex items-start justify-between gap-4">
+              <div>
+                <p className="font-semibold text-gray-800">Recordatorios de eventos</p>
+                <p className="text-xs text-gray-500">Notificaciones push 30 minutos antes de cada reunión.</p>
+              </div>
+              <span className="rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold text-emerald-600">Activo</span>
+            </li>
+            <li className="flex items-start justify-between gap-4">
+              <div>
+                <p className="font-semibold text-gray-800">Resúmenes diarios</p>
+                <p className="text-xs text-gray-500">Envío a primera hora con los eventos y tareas del día.</p>
+              </div>
+              <span className="rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold text-amber-600">Programado</span>
+            </li>
+            <li className="flex items-start justify-between gap-4">
+              <div>
+                <p className="font-semibold text-gray-800">Alertas de equipos</p>
+                <p className="text-xs text-gray-500">Recibe avisos cuando tu equipo actualice la agenda compartida.</p>
+              </div>
+              <span className="rounded-full bg-rose-100 px-3 py-1 text-xs font-semibold text-rose-600">Silenciado</span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/Calendar.tsx
+++ b/frontend/components/Calendar.tsx
@@ -1,0 +1,76 @@
+const weekDays = ["L", "M", "X", "J", "V", "S", "D"];
+
+function buildCalendarDates(date: Date) {
+  const firstDay = new Date(date.getFullYear(), date.getMonth(), 1);
+  const lastDay = new Date(date.getFullYear(), date.getMonth() + 1, 0);
+
+  const startOffset = (firstDay.getDay() + 6) % 7; // Convertir domingo=0 a lunes=0
+  const totalDays = lastDay.getDate();
+
+  const days: (number | null)[] = [];
+  for (let i = 0; i < startOffset; i += 1) {
+    days.push(null);
+  }
+  for (let day = 1; day <= totalDays; day += 1) {
+    days.push(day);
+  }
+
+  const remainder = days.length % 7;
+  if (remainder !== 0) {
+    for (let i = remainder; i < 7; i += 1) {
+      days.push(null);
+    }
+  }
+
+  return days;
+}
+
+export default function Calendar() {
+  const today = new Date();
+  const monthLabel = today.toLocaleDateString("es-ES", {
+    month: "long",
+    year: "numeric",
+  });
+
+  const days = buildCalendarDates(today);
+
+  return (
+    <section className="rounded-2xl bg-white p-6 shadow-sm">
+      <header className="mb-6 flex items-center justify-between">
+        <div>
+          <p className="text-sm font-medium uppercase tracking-wide text-indigo-500">Calendario</p>
+          <h3 className="text-xl font-semibold capitalize text-gray-900">{monthLabel}</h3>
+        </div>
+        <div className="flex items-center gap-2 text-xs text-gray-500">
+          <span className="inline-flex items-center gap-1 rounded-full bg-indigo-50 px-2 py-1 font-medium text-indigo-600">
+            ● Hoy
+          </span>
+        </div>
+      </header>
+      <div className="grid grid-cols-7 gap-2 text-center text-sm">
+        {weekDays.map((day) => (
+          <span key={day} className="font-semibold uppercase tracking-wide text-gray-400">
+            {day}
+          </span>
+        ))}
+        {days.map((day, index) => {
+          const isToday = day === today.getDate();
+          return (
+            <div
+              key={`${day ?? "empty"}-${index}`}
+              className={`flex h-12 items-center justify-center rounded-xl border text-sm transition ${
+                day
+                  ? isToday
+                    ? "border-indigo-500 bg-indigo-50 font-semibold text-indigo-600"
+                    : "border-transparent bg-gray-50 text-gray-700 hover:border-indigo-200"
+                  : "border-transparent"
+              }`}
+            >
+              {day ?? ""}
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/frontend/components/EventCard.tsx
+++ b/frontend/components/EventCard.tsx
@@ -1,0 +1,42 @@
+interface EventCardProps {
+  time: string;
+  title: string;
+  icon?: string;
+  location?: string;
+  description?: string;
+  tag?: string;
+}
+
+export default function EventCard({
+  time,
+  title,
+  icon = "🗓️",
+  location,
+  description,
+  tag,
+}: EventCardProps) {
+  return (
+    <article className="flex items-start gap-4 rounded-2xl border border-gray-100 bg-white p-5 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md">
+      <div className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-xl bg-indigo-50 text-2xl">
+        {icon}
+      </div>
+      <div className="flex flex-1 flex-col">
+        <div className="flex flex-wrap items-center gap-2">
+          <h4 className="text-base font-semibold text-gray-900">{title}</h4>
+          {tag ? (
+            <span className="inline-flex items-center rounded-full bg-emerald-50 px-2.5 py-0.5 text-xs font-semibold text-emerald-600">
+              {tag}
+            </span>
+          ) : null}
+        </div>
+        <p className="mt-1 text-sm font-medium text-gray-500">{time}</p>
+        {location ? (
+          <p className="mt-1 text-sm text-gray-500">
+            <span className="font-medium text-gray-600">Lugar:</span> {location}
+          </p>
+        ) : null}
+        {description ? <p className="mt-2 text-sm text-gray-600">{description}</p> : null}
+      </div>
+    </article>
+  );
+}

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import Link from "next/link";
+
+const breadcrumbs: Record<string, string> = {
+  "/": "Dashboard",
+  "/dashboard": "Agenda",
+  "/settings": "Configuración",
+};
+
+export default function Header() {
+  const pathname = usePathname();
+  const title = breadcrumbs[pathname] ?? "Dashboard";
+
+  return (
+    <header className="sticky top-0 z-30 border-b border-gray-200 bg-white/80 backdrop-blur">
+      <div className="flex items-center justify-between gap-4 px-4 py-4 sm:px-6 lg:px-10">
+        <div>
+          <nav className="text-sm text-gray-500">
+            <ol className="flex items-center gap-2">
+              <li>
+                <Link href="/" className="hover:text-gray-700">
+                  Agenda Inteligente
+                </Link>
+              </li>
+              <li className="text-gray-300">/</li>
+              <li className="font-semibold text-gray-900">{title}</li>
+            </ol>
+          </nav>
+          <h1 className="text-2xl font-semibold text-gray-900">{title}</h1>
+        </div>
+        <div className="flex items-center gap-4">
+          <button className="hidden rounded-full border border-gray-200 px-4 py-2 text-sm font-medium text-gray-600 shadow-sm transition hover:border-gray-300 hover:bg-white sm:inline-flex">
+            Exportar agenda
+          </button>
+          <button className="inline-flex items-center gap-2 rounded-full bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500">
+            <span className="text-lg">＋</span>
+            Nuevo evento
+          </button>
+          <div className="flex h-10 w-10 items-center justify-center overflow-hidden rounded-full border border-gray-200 bg-gray-100">
+            <span role="img" aria-label="Usuario" className="text-lg">
+              😊
+            </span>
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/frontend/components/LoadingSpinner.tsx
+++ b/frontend/components/LoadingSpinner.tsx
@@ -1,0 +1,7 @@
+export default function LoadingSpinner() {
+  return (
+    <div className="flex items-center justify-center">
+      <div className="h-12 w-12 animate-spin rounded-full border-4 border-indigo-200 border-t-indigo-600" aria-label="Cargando" />
+    </div>
+  );
+}

--- a/frontend/components/Sidebar.tsx
+++ b/frontend/components/Sidebar.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const navigation = [
+  { name: "Inicio", href: "/", icon: "🏠" },
+  { name: "Dashboard", href: "/dashboard", icon: "📊" },
+  { name: "Equipos", href: "/teams", icon: "👥" },
+  { name: "Eventos", href: "/events", icon: "📅" },
+  { name: "Tareas", href: "/tasks", icon: "✅" },
+  { name: "Integraciones", href: "/integrations", icon: "🔗" },
+  { name: "Configuración", href: "/settings", icon: "⚙️" },
+  { name: "Soporte", href: "/support", icon: "💬" },
+];
+
+export default function Sidebar() {
+  const pathname = usePathname();
+
+  return (
+    <aside className="fixed inset-y-0 left-0 z-40 hidden w-64 flex-col border-r border-gray-800 bg-gray-900 p-6 text-white shadow-xl md:flex">
+      <div className="mb-8">
+        <span className="text-sm font-semibold uppercase tracking-widest text-indigo-400">
+          Agenda Inteligente
+        </span>
+        <h2 className="mt-2 text-2xl font-bold">Panel</h2>
+      </div>
+      <nav className="flex flex-1 flex-col gap-1 text-sm">
+        {navigation.map((item) => {
+          const isActive = pathname === item.href || (item.href !== "/" && pathname.startsWith(item.href));
+          return (
+            <Link
+              key={item.name}
+              href={item.href}
+              className={`flex items-center gap-3 rounded-xl px-3 py-2 transition ${
+                isActive ? "bg-gray-800 text-white" : "text-gray-300 hover:bg-gray-800/60 hover:text-white"
+              }`}
+            >
+              <span className="text-lg">{item.icon}</span>
+              <span className="font-medium">{item.name}</span>
+            </Link>
+          );
+        })}
+      </nav>
+      <div className="mt-6 rounded-xl border border-white/10 bg-white/5 p-4 text-xs text-gray-200">
+        <p className="font-semibold text-white">Sincroniza tu agenda</p>
+        <p className="mt-1 text-gray-300">
+          Conecta tus cuentas para mantener tus eventos siempre actualizados.
+        </p>
+        <button className="mt-4 inline-flex items-center justify-center rounded-lg bg-indigo-500 px-3 py-2 text-xs font-semibold text-white transition hover:bg-indigo-400">
+          Conectar ahora
+        </button>
+      </div>
+    </aside>
+  );
+}

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -1,0 +1,27 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html,
+body {
+  min-height: 100%;
+  scroll-behavior: smooth;
+}
+
+body {
+  background-color: theme("colors.gray.50");
+}
+
+::selection {
+  background-color: theme("colors.indigo.200");
+  color: theme("colors.indigo.900");
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button {
+  outline: none;
+}

--- a/frontend/styles/theme.css
+++ b/frontend/styles/theme.css
@@ -1,0 +1,16 @@
+:root {
+  --sidebar-width: 16rem;
+  --color-primary: #4f46e5;
+  --color-secondary: #6366f1;
+  --color-accent: #22d3ee;
+  --radius-xl: 1.5rem;
+  --shadow-soft: 0 10px 30px rgba(15, 23, 42, 0.08);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-primary: #818cf8;
+    --color-secondary: #a5b4fc;
+    --color-accent: #67e8f9;
+  }
+}


### PR DESCRIPTION
## Summary
- implement the global layout with fixed sidebar and sticky header for the Agenda Inteligente dashboard
- build dashboard, extended agenda, and settings views with reusable calendar, event card, and loading spinner components
- add global styling, theme variables, mock events API, and ignore node-related build artifacts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6909405e8b848327aa1f66ad8739c39e