### PR TITLE
Refactor layouts to isolate login page

### DIFF
--- a/frontend/app/(panel)/dashboard/page.tsx
+++ b/frontend/app/(panel)/dashboard/page.tsx
@@ -1,7 +1,9 @@
-import Calendar from "../../components/Calendar";
-import EventCard from "../../components/EventCard";
-import LoadingSpinner from "../../components/LoadingSpinner";
+// Importamos los componentes compartidos utilizando rutas relativas al nuevo grupo de rutas.
+import Calendar from "../../../components/Calendar";
+import EventCard from "../../../components/EventCard";
+import LoadingSpinner from "../../../components/LoadingSpinner";
 
+// Datos de ejemplo para los eventos del equipo mostrados en el dashboard.
 const teamEvents = [
   {
     time: "08:30",
@@ -29,6 +31,7 @@ const teamEvents = [
 export default function DashboardPage() {
   return (
     <div className="space-y-8">
+      {/* Introducción al módulo con un resumen del objetivo de la sección. */}
       <section>
         <h2 className="text-3xl font-semibold text-gray-900">Agenda detallada</h2>
         <p className="mt-1 text-sm text-gray-500">
@@ -36,6 +39,7 @@ export default function DashboardPage() {
         </p>
       </section>
 
+      {/* Distribución principal del dashboard con eventos y calendario. */}
       <section className="grid gap-6 lg:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)]">
         <div className="space-y-4">
           <div className="rounded-2xl bg-white p-6 shadow-sm">

--- a/frontend/app/(panel)/layout.tsx
+++ b/frontend/app/(panel)/layout.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from "react";
+import Header from "../../components/Header";
+import Sidebar from "../../components/Sidebar";
+
+// Layout específico del panel administrativo.
+// Al ubicarse dentro del grupo de rutas (panel), solo se aplica a las páginas del dashboard,
+// manteniendo aisladas rutas como /login que no deben mostrar la navegación lateral.
+export default function PanelLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex min-h-screen w-full bg-gray-50">
+      {/* Barra lateral fija del panel. */}
+      <Sidebar />
+
+      {/* Contenedor principal donde se muestran el header y el contenido dinámico. */}
+      <div className="flex min-h-screen flex-1 flex-col md:ml-64">
+        {/* Encabezado superior del panel con acciones y avatar. */}
+        <Header />
+
+        {/* Área central que renderiza la página hija correspondiente (dashboard, settings, etc.). */}
+        <main className="flex-1 px-4 py-6 sm:px-6 lg:px-10">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/(panel)/page.tsx
+++ b/frontend/app/(panel)/page.tsx
@@ -1,5 +1,6 @@
-import Calendar from "../components/Calendar";
-import EventCard from "../components/EventCard";
+// Importamos los componentes reutilizables del dashboard desde la carpeta global de componentes.
+import Calendar from "../../components/Calendar";
+import EventCard from "../../components/EventCard";
 
 const upcomingEvents = [
   {
@@ -59,6 +60,7 @@ const summaryCards = [
 export default function HomePage() {
   return (
     <div className="space-y-8">
+      {/* Encabezado de bienvenida que contextualiza al usuario. */}
       <section className="flex flex-col gap-2">
         <p className="text-sm font-medium text-gray-500">Bienvenido,</p>
         <h2 className="text-3xl font-semibold text-gray-900">Bienvenido, Daniela 👋</h2>
@@ -67,6 +69,7 @@ export default function HomePage() {
         </p>
       </section>
 
+      {/* Resumen en tarjetas con los principales indicadores del día. */}
       <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
         {summaryCards.map((card) => (
           <div key={card.title} className="rounded-2xl bg-white p-5 shadow-sm">
@@ -80,6 +83,7 @@ export default function HomePage() {
         ))}
       </section>
 
+      {/* Bloque principal con la lista de eventos próximos y el calendario interactivo. */}
       <section className="grid gap-6 lg:grid-cols-[minmax(0,1.15fr)_minmax(0,1fr)]">
         <div className="space-y-4">
           <header className="flex items-center justify-between">

--- a/frontend/app/(panel)/settings/page.tsx
+++ b/frontend/app/(panel)/settings/page.tsx
@@ -1,6 +1,8 @@
+// Página de configuración que se beneficia del layout del panel al estar dentro del grupo (panel).
 export default function SettingsPage() {
   return (
     <div className="space-y-8">
+      {/* Título y descripción general de la vista de configuración. */}
       <section>
         <h2 className="text-3xl font-semibold text-gray-900">Configuración de cuenta</h2>
         <p className="mt-2 text-sm text-gray-500">
@@ -9,6 +11,7 @@ export default function SettingsPage() {
       </section>
 
       <div className="grid gap-6 lg:grid-cols-2">
+        {/* Formulario principal con los datos personales del usuario. */}
         <form className="space-y-5 rounded-2xl bg-white p-6 shadow-sm">
           <div>
             <label htmlFor="name" className="text-sm font-semibold text-gray-700">
@@ -47,6 +50,7 @@ export default function SettingsPage() {
             Guardar cambios
           </button>
         </form>
+        {/* Tarjeta secundaria con opciones de notificaciones. */}
         <div className="space-y-5 rounded-2xl bg-white p-6 shadow-sm">
           <div>
             <h3 className="text-lg font-semibold text-gray-900">Notificaciones</h3>

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,18 +1,22 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import type { ReactNode } from "react";
-import Header from "../components/Header";
-import Sidebar from "../components/Sidebar";
 import "../styles/globals.css";
 import "../styles/theme.css";
 
+// Inicializamos la fuente Inter para tener una tipografía consistente en toda la aplicación.
 const inter = Inter({ subsets: ["latin"], display: "swap" });
 
+// Definimos los metadatos globales que usará Next.js para todas las páginas.
 export const metadata: Metadata = {
   title: "Agenda Inteligente",
   description: "Dashboard principal de Agenda Inteligente",
 };
 
+// Este layout raíz solo envuelve la aplicación con las etiquetas <html> y <body>.
+// Al no renderizar aquí el sidebar ni el header, evitamos que rutas especiales como /login
+// hereden el diseño del panel administrativo. Las secciones del panel tendrán su propio
+// layout dedicado dentro de un grupo de rutas.
 export default function RootLayout({
   children,
 }: {
@@ -20,14 +24,10 @@ export default function RootLayout({
 }) {
   return (
     <html lang="es">
+      {/* Aplicamos la fuente y colores de fondo base a todo el proyecto. */}
       <body className={`${inter.className} bg-gray-50 text-gray-900`}>
-        <div className="flex min-h-screen w-full bg-gray-50">
-          <Sidebar />
-          <div className="flex min-h-screen flex-1 flex-col md:ml-64">
-            <Header />
-            <main className="flex-1 px-4 py-6 sm:px-6 lg:px-10">{children}</main>
-          </div>
-        </div>
+        {/* Renderizamos el contenido específico de cada página o layout anidado. */}
+        {children}
       </body>
     </html>
   );

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+// Esta página se renderiza con el layout raíz minimalista, por lo que no hereda el sidebar ni el header del panel.
+
 import "./login.css"; // 👈 importamos nuestro CSS del login
 import { useState } from "react";
 


### PR DESCRIPTION
## Summary
- simplify the root layout so special routes como /login no heredan la interfaz del panel
- crear un layout exclusivo dentro del grupo de rutas (panel) con sidebar y header para el dashboard
- mover las páginas del panel al nuevo grupo y actualizar comentarios e imports

## Testing
- npm run lint *(falla: comando `next` no encontrado en el entorno)*

------
https://chatgpt.com/codex/tasks/task_e_69096ddcbf248327a3e96ded991beee4