### PR TITLE
Implement SQLite-backed authentication APIs

### DIFF
--- a/frontend/app/api/login/route.ts
+++ b/frontend/app/api/login/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from "next/server";
+import bcrypt from "bcrypt";
+import { getUserByEmail } from "@/lib/db";
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const correo: string | undefined = body?.correo;
+    const contrasena: string | undefined = body?.contraseña;
+
+    if (!correo || !contrasena) {
+      return NextResponse.json(
+        {
+          ok: false,
+          message: "Correo y contraseña son requeridos",
+        },
+        { status: 400 }
+      );
+    }
+
+    const user = getUserByEmail(correo);
+
+    if (!user) {
+      return NextResponse.json(
+        {
+          ok: false,
+          message: "Credenciales inválidas",
+        },
+        { status: 401 }
+      );
+    }
+
+    const isPasswordValid = await bcrypt.compare(contrasena, user.contraseña_hash);
+
+    if (!isPasswordValid) {
+      return NextResponse.json(
+        {
+          ok: false,
+          message: "Credenciales inválidas",
+        },
+        { status: 401 }
+      );
+    }
+
+    return NextResponse.json({
+      ok: true,
+      usuario: {
+        id: user.id,
+        nombre: user.nombre,
+        correo: user.correo,
+      },
+    });
+  } catch (error) {
+    console.error("Error en el inicio de sesión", error);
+
+    return NextResponse.json(
+      {
+        ok: false,
+        message: "Error interno del servidor",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/app/api/register/route.ts
+++ b/frontend/app/api/register/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createUser, getUserByEmail } from "@/lib/db";
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const nombre: string | undefined = body?.nombre;
+    const correo: string | undefined = body?.correo;
+    const contrasena: string | undefined = body?.contraseña;
+
+    if (!nombre || !correo || !contrasena) {
+      return NextResponse.json(
+        {
+          ok: false,
+          message: "Todos los campos son obligatorios",
+        },
+        { status: 400 }
+      );
+    }
+
+    const existingUser = getUserByEmail(correo);
+
+    if (existingUser) {
+      return NextResponse.json(
+        {
+          ok: false,
+          message: "El correo ya se encuentra registrado",
+        },
+        { status: 400 }
+      );
+    }
+
+    const user = await createUser(nombre, correo, contrasena);
+
+    return NextResponse.json(
+      {
+        ok: true,
+        usuario: user,
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    console.error("Error al registrar usuario", error);
+
+    return NextResponse.json(
+      {
+        ok: false,
+        message: "Error interno del servidor",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/app/register/page.tsx
+++ b/frontend/app/register/page.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import "./register.css";
+import { useState } from "react";
+
+interface RegisterResponse {
+  ok: boolean;
+  message?: string;
+  usuario?: {
+    id: number;
+    nombre: string;
+    correo: string;
+  };
+}
+
+export default function RegisterPage() {
+  const [nombre, setNombre] = useState("");
+  const [correo, setCorreo] = useState("");
+  const [password, setPassword] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setIsLoading(true);
+    setError(null);
+    setSuccessMessage(null);
+
+    try {
+      const response = await fetch("/api/register", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ nombre, correo, contraseña: password }),
+      });
+
+      const data = (await response.json()) as RegisterResponse;
+
+      if (!response.ok || !data.ok) {
+        setError(data.message ?? "No fue posible registrar al usuario");
+        return;
+      }
+
+      setSuccessMessage("Tu cuenta fue creada exitosamente. ¡Ahora puedes iniciar sesión!");
+      setNombre("");
+      setCorreo("");
+      setPassword("");
+    } catch (err) {
+      console.error("Error al registrar usuario", err);
+      setError("No fue posible conectar con el servidor. Inténtalo más tarde.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="register-container">
+      <form onSubmit={handleSubmit} className="register-card">
+        <h1 className="register-title">Crear cuenta</h1>
+
+        <div className="register-field">
+          <label htmlFor="nombre">Nombre completo</label>
+          <input
+            id="nombre"
+            type="text"
+            value={nombre}
+            onChange={(event) => setNombre(event.target.value)}
+            placeholder="Nombre Apellido"
+            required
+          />
+        </div>
+
+        <div className="register-field">
+          <label htmlFor="correo">Correo electrónico</label>
+          <input
+            id="correo"
+            type="email"
+            value={correo}
+            onChange={(event) => setCorreo(event.target.value)}
+            placeholder="tu@correo.com"
+            required
+          />
+        </div>
+
+        <div className="register-field">
+          <label htmlFor="password">Contraseña</label>
+          <input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            placeholder="••••••••"
+            required
+          />
+        </div>
+
+        <button type="submit" className="register-btn" disabled={isLoading}>
+          {isLoading ? "Creando cuenta..." : "Registrarme"}
+        </button>
+
+        {error ? (
+          <p className="register-error" role="alert">
+            {error}
+          </p>
+        ) : null}
+
+        {successMessage ? (
+          <p className="register-success" role="status">
+            {successMessage}
+          </p>
+        ) : null}
+
+        <p className="register-footer">
+          ¿Ya tienes cuenta?{" "}
+          <a href="/login" className="register-link">
+            Inicia sesión
+          </a>
+        </p>
+      </form>
+    </div>
+  );
+}

--- a/frontend/app/register/register.css
+++ b/frontend/app/register/register.css
@@ -1,53 +1,47 @@
-/* === Contenedor general === */
-.login-container {
+.register-container {
   @apply min-h-screen flex items-center justify-center bg-gray-50;
 }
 
-/* === Tarjeta del formulario === */
-.login-card {
-  @apply w-full max-w-sm bg-white p-8 rounded-2xl shadow-lg;
+.register-card {
+  @apply w-full max-w-md bg-white p-8 rounded-2xl shadow-lg;
 }
 
-/* === Título === */
-.login-title {
+.register-title {
   @apply text-2xl font-bold text-center mb-6 text-gray-800;
 }
 
-/* === Campos (label + input) === */
-.login-field {
+.register-field {
   @apply mb-5;
 }
 
-.login-field label {
+.register-field label {
   @apply block text-sm font-medium text-gray-700 mb-1;
 }
 
-.login-field input {
+.register-field input {
   @apply w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500;
 }
 
-/* === Botón === */
-.login-btn {
+.register-btn {
   @apply w-full bg-indigo-600 text-white py-2 rounded-lg hover:bg-indigo-700 transition;
 }
 
-.login-btn:disabled {
+.register-btn:disabled {
   @apply opacity-70 cursor-not-allowed;
 }
 
-.login-error {
+.register-error {
   @apply mt-4 text-sm text-red-600 text-center;
 }
 
-.login-success {
+.register-success {
   @apply mt-4 text-sm text-green-600 text-center;
 }
 
-/* === Footer (enlace) === */
-.login-footer {
+.register-footer {
   @apply text-sm text-gray-500 mt-4 text-center;
 }
 
-.login-link {
+.register-link {
   @apply text-indigo-600 hover:underline;
 }

--- a/frontend/lib/db.ts
+++ b/frontend/lib/db.ts
@@ -1,0 +1,66 @@
+import Database from "better-sqlite3";
+import bcrypt from "bcrypt";
+import path from "path";
+
+const dbPath = path.resolve("/data/app.db");
+console.log(`[DB] Using SQLite database at ${dbPath}`);
+
+const db = new Database(dbPath, { fileMustExist: true });
+
+export interface UsuarioRow {
+  id: number;
+  nombre: string;
+  correo: string;
+  contraseña_hash: string;
+  zona_horaria?: string | null;
+  creado_en?: string;
+}
+
+export interface PublicUser {
+  id: number;
+  nombre: string;
+  correo: string;
+}
+
+const getUserByEmailStatement = db.prepare<[string], UsuarioRow>(
+  "SELECT id, nombre, correo, contraseña_hash, zona_horaria, creado_en FROM usuarios WHERE correo = ?"
+);
+
+const getUserByIdStatement = db.prepare<[number], PublicUser>(
+  "SELECT id, nombre, correo FROM usuarios WHERE id = ?"
+);
+
+export function getUserByEmail(correo: string): UsuarioRow | undefined {
+  if (!correo) {
+    return undefined;
+  }
+
+  return getUserByEmailStatement.get(correo) ?? undefined;
+}
+
+export async function createUser(
+  nombre: string,
+  correo: string,
+  contraseña: string
+): Promise<PublicUser> {
+  if (!nombre || !correo || !contraseña) {
+    throw new Error("Nombre, correo y contraseña son requeridos");
+  }
+
+  const contraseñaHash = await bcrypt.hash(contraseña, 10);
+
+  const insertStatement = db.prepare(
+    "INSERT INTO usuarios (nombre, correo, contraseña_hash, zona_horaria, creado_en) VALUES (?, ?, ?, NULL, datetime('now'))"
+  );
+
+  const result = insertStatement.run(nombre, correo, contraseñaHash);
+  const insertedId = Number(result.lastInsertRowid);
+
+  const user = getUserByIdStatement.get(insertedId);
+
+  if (!user) {
+    throw new Error("No se pudo recuperar el usuario insertado");
+  }
+
+  return user;
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "bcrypt": "^5.1.1",
+    "better-sqlite3": "^11.5.0",
     "next": "latest",
     "react": "latest",
     "react-dom": "latest"

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -13,6 +13,10 @@
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "node",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    },
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
## Summary
- connect to the existing SQLite database with helper methods for looking up and creating users
- add `/api/login` and `/api/register` endpoints that validate credentials with bcrypt and return sanitized user data
- hook the login form to the API, add a styled registration page, and configure path aliases and dependencies for shared imports

## Testing
- npm install *(fails: 403 Forbidden when fetching bcrypt)*

------
https://chatgpt.com/codex/tasks/task_e_690979b32b408327b14d3aa2213759eb