### PR TITLE
Refactor auth stack for sqlite3 compatibility

### DIFF
--- a/frontend/app/api/login/route.ts
+++ b/frontend/app/api/login/route.ts
@@ -1,12 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
-import bcrypt from "bcrypt";
+import bcrypt from "bcryptjs";
 import { getUserByEmail } from "@/lib/db";
 
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
-    const correo: string | undefined = body?.correo;
-    const contrasena: string | undefined = body?.contraseña;
+    const correo: string | undefined =
+      typeof body?.correo === "string" ? body.correo.trim().toLowerCase() : undefined;
+    const contrasena: string | undefined =
+      typeof body?.contraseña === "string" ? body.contraseña : undefined;
 
     if (!correo || !contrasena) {
       return NextResponse.json(
@@ -18,7 +20,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const user = getUserByEmail(correo);
+    const user = await getUserByEmail(correo);
 
     if (!user) {
       return NextResponse.json(

--- a/frontend/app/api/register/route.ts
+++ b/frontend/app/api/register/route.ts
@@ -4,9 +4,12 @@ import { createUser, getUserByEmail } from "@/lib/db";
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
-    const nombre: string | undefined = body?.nombre;
-    const correo: string | undefined = body?.correo;
-    const contrasena: string | undefined = body?.contraseña;
+    const nombre: string | undefined =
+      typeof body?.nombre === "string" ? body.nombre.trim() : undefined;
+    const correo: string | undefined =
+      typeof body?.correo === "string" ? body.correo.trim().toLowerCase() : undefined;
+    const contrasena: string | undefined =
+      typeof body?.contraseña === "string" ? body.contraseña : undefined;
 
     if (!nombre || !correo || !contrasena) {
       return NextResponse.json(
@@ -18,7 +21,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const existingUser = getUserByEmail(correo);
+    const existingUser = await getUserByEmail(correo);
 
     if (existingUser) {
       return NextResponse.json(
@@ -30,15 +33,34 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const user = await createUser(nombre, correo, contrasena);
+    try {
+      const user = await createUser(nombre, correo, contrasena);
 
-    return NextResponse.json(
-      {
-        ok: true,
-        usuario: user,
-      },
-      { status: 201 }
-    );
+      return NextResponse.json(
+        {
+          ok: true,
+          usuario: user,
+        },
+        { status: 201 }
+      );
+    } catch (error) {
+      console.error("Error al crear usuario", error);
+
+      const isUniqueConstraint =
+        error instanceof Error && /UNIQUE|constraint/i.test(error.message);
+      const message = isUniqueConstraint
+        ? "El correo ya se encuentra registrado"
+        : "No fue posible registrar al usuario";
+      const status = isUniqueConstraint ? 409 : 500;
+
+      return NextResponse.json(
+        {
+          ok: false,
+          message,
+        },
+        { status }
+      );
+    }
   } catch (error) {
     console.error("Error al registrar usuario", error);
 

--- a/frontend/app/login/login.css
+++ b/frontend/app/login/login.css
@@ -45,7 +45,7 @@
 
 /* === Footer (enlace) === */
 .login-footer {
-  @apply text-sm text-gray-500 mt-4 text-center;
+  @apply text-sm text-gray-500 mt-4 text-center space-y-2;
 }
 
 .login-link {

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -3,7 +3,8 @@
 // Esta página se renderiza con el layout raíz minimalista, por lo que no hereda el sidebar ni el header del panel.
 
 import "./login.css"; // 👈 importamos nuestro CSS del login
-import { useState } from "react";
+import Link from "next/link";
+import { FormEvent, useState } from "react";
 
 interface LoginResponse {
   ok: boolean;
@@ -22,7 +23,7 @@ export default function LoginPage() {
   const [error, setError] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
-  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setIsLoading(true);
     setError(null);
@@ -45,6 +46,7 @@ export default function LoginPage() {
       }
 
       setSuccessMessage(`¡Bienvenido de nuevo, ${data.usuario?.nombre ?? ""}!`);
+      setPassword("");
     } catch (err) {
       console.error("Error al intentar iniciar sesión", err);
       setError("No fue posible conectar con el servidor. Inténtalo más tarde.");
@@ -98,12 +100,20 @@ export default function LoginPage() {
           </p>
         ) : null}
 
-        <p className="login-footer">
-          ¿Olvidaste tu contraseña?{" "}
-          <a href="#" className="login-link">
-            Recuperar
-          </a>
-        </p>
+        <div className="login-footer">
+          <p>
+            ¿Olvidaste tu contraseña?{" "}
+            <a href="#" className="login-link">
+              Recuperar
+            </a>
+          </p>
+          <p>
+            ¿Aún no tienes cuenta?{" "}
+            <Link href="/register" className="login-link">
+              Crear cuenta
+            </Link>
+          </p>
+        </div>
       </form>
     </div>
   );

--- a/frontend/app/register/page.tsx
+++ b/frontend/app/register/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import "./register.css";
-import { useState } from "react";
+import Link from "next/link";
+import { FormEvent, useState } from "react";
 
 interface RegisterResponse {
   ok: boolean;
@@ -21,7 +22,7 @@ export default function RegisterPage() {
   const [error, setError] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
-  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setIsLoading(true);
     setError(null);
@@ -114,9 +115,9 @@ export default function RegisterPage() {
 
         <p className="register-footer">
           ¿Ya tienes cuenta?{" "}
-          <a href="/login" className="register-link">
+          <Link href="/login" className="register-link">
             Inicia sesión
-          </a>
+          </Link>
         </p>
       </form>
     </div>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,9 +8,11 @@
       "name": "agenda-inteligente-frontend",
       "version": "1.0.0",
       "dependencies": {
+        "bcryptjs": "^2.4.3",
         "next": "latest",
         "react": "latest",
-        "react-dom": "latest"
+        "react-dom": "latest",
+        "sqlite3": "^5.1.7"
       },
       "devDependencies": {
         "@types/node": "24.10.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,11 +9,11 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "bcrypt": "^5.1.1",
-    "better-sqlite3": "^11.5.0",
+    "bcryptjs": "^2.4.3",
     "next": "latest",
     "react": "latest",
-    "react-dom": "latest"
+    "react-dom": "latest",
+    "sqlite3": "^5.1.7"
   },
   "devDependencies": {
     "@types/node": "24.10.0",

--- a/frontend/types/bcryptjs.d.ts
+++ b/frontend/types/bcryptjs.d.ts
@@ -1,0 +1,8 @@
+declare module "bcryptjs" {
+  export function hash(data: string, salt: number | string): Promise<string>;
+  export function hashSync(data: string, salt: number | string): string;
+  export function compare(data: string, encrypted: string): Promise<boolean>;
+  export function compareSync(data: string, encrypted: string): boolean;
+  export function genSalt(rounds?: number): Promise<string>;
+  export function genSaltSync(rounds?: number): string;
+}

--- a/frontend/types/sqlite3.d.ts
+++ b/frontend/types/sqlite3.d.ts
@@ -1,0 +1,33 @@
+declare module "sqlite3" {
+  export interface RunResult {
+    lastID: number;
+    changes: number;
+  }
+
+  export type Callback = (error: Error | null) => void;
+
+  export class Database {
+    constructor(filename: string, mode?: number, callback?: Callback);
+    run(sql: string, callback?: (this: RunResult, error: Error | null) => void): this;
+    run(sql: string, params: unknown[], callback?: (this: RunResult, error: Error | null) => void): this;
+    get<T>(sql: string, callback: (error: Error | null, row: T | undefined) => void): void;
+    get<T>(sql: string, params: unknown[], callback: (error: Error | null, row: T | undefined) => void): void;
+    close(callback?: Callback): void;
+  }
+
+  export const OPEN_READONLY: number;
+  export const OPEN_READWRITE: number;
+  export const OPEN_CREATE: number;
+
+  export function verbose(): typeof import("sqlite3");
+
+  const sqlite3: {
+    Database: typeof Database;
+    OPEN_READONLY: typeof OPEN_READONLY;
+    OPEN_READWRITE: typeof OPEN_READWRITE;
+    OPEN_CREATE: typeof OPEN_CREATE;
+    verbose: typeof verbose;
+  };
+
+  export default sqlite3;
+}


### PR DESCRIPTION
## Summary
- replace the native better-sqlite3 usage with a promise-based sqlite3 helper and add local type declarations
- switch all authentication utilities and API routes to bcryptjs and async database helpers while improving error messaging
- refresh the login and register client pages with navigation between them and consistent success/error handling

## Testing
- npm run lint *(fails: dependencies could not be installed because the registry blocks bcryptjs in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_6909802502c08327bbdbb86400694d25