### PR TITLE
fix: regenerate bcrypt hashes for seeded users

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -13,7 +13,7 @@ CREATE TABLE IF NOT EXISTS usuarios (
     id              INTEGER PRIMARY KEY AUTOINCREMENT,
     nombre          VARCHAR(100) NOT NULL,
     correo          VARCHAR(150) UNIQUE NOT NULL,
-    contraseña_hash VARCHAR(255),
+    password_hash   TEXT NOT NULL,
     zona_horaria    VARCHAR(50) DEFAULT 'America/Mexico_City',
     creado_en       DATETIME DEFAULT CURRENT_TIMESTAMP
 );

--- a/db/seed.sql
+++ b/db/seed.sql
@@ -4,9 +4,9 @@
 
 PRAGMA foreign_keys = ON;
 
--- Inserta usuarios base (sin hash por ahora)
-INSERT INTO usuarios (nombre, correo, contraseña_hash, zona_horaria)
+-- Inserta usuarios base con contraseñas cifradas en bcrypt
+INSERT INTO usuarios (nombre, correo, password_hash, zona_horaria)
 VALUES
-    ('Daniel',   'daniel@example.com',   'dan123',   'America/Mexico_City'),
-    ('Adrián',   'adrian@example.com',   'adr123',   'America/Mexico_City'),
-    ('Sebastián','sebastian@example.com','seb123',   'America/Mexico_City');
+    ('Daniel',   'daniel@correo.com',   '$2y$10$vumSDY3.6wPPqFwpJ5PxAettRW0TgrUIblFdxPUcYw5Aq47h.IglO',   'America/Mexico_City'),
+    ('Adrián',   'adrian@correo.com',   '$2y$10$lL09MVtQwLpwglXWGvec9OVVCBCmtAoQMIUnWn4Dk3b334r3MbQGS',   'America/Mexico_City'),
+    ('Sebastián','sebastian@correo.com','$2y$10$0KABdqRFzf2StNEF2Zn3n.1/poMOcAu0rBhDPYZGhsvptcJFNV0QW',   'America/Mexico_City');

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "verify:passwords": "node scripts/verify-passwords.js"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",

--- a/frontend/scripts/verify-passwords.js
+++ b/frontend/scripts/verify-passwords.js
@@ -1,0 +1,58 @@
+const path = require("path");
+const fs = require("fs");
+const sqlite3 = require("sqlite3").verbose();
+const bcrypt = require("bcryptjs");
+
+const dbPath = path.join(__dirname, "..", "..", "data", "app.db");
+
+const credentials = [
+  { correo: "daniel@correo.com", password: "dan123" },
+  { correo: "adrian@correo.com", password: "chuy123" },
+];
+
+if (!fs.existsSync(dbPath)) {
+  console.error(`[verify-passwords] No se encontró la base de datos en ${dbPath}`);
+  process.exitCode = 1;
+  process.exit();
+}
+
+const db = new sqlite3.Database(dbPath, sqlite3.OPEN_READONLY, (err) => {
+  if (err) {
+    console.error("[verify-passwords] Error al abrir la base de datos:", err.message);
+    process.exit(1);
+  }
+});
+
+db.serialize(async () => {
+  try {
+    for (const cred of credentials) {
+      const row = await new Promise((resolve, reject) => {
+        db.get(
+          "SELECT id, nombre, correo, password_hash FROM usuarios WHERE correo = ?",
+          [cred.correo],
+          (error, result) => {
+            if (error) reject(error);
+            else resolve(result);
+          }
+        );
+      });
+
+      if (!row) {
+        console.error(`❌ Usuario no encontrado: ${cred.correo}`);
+        continue;
+      }
+
+      const isValid = await bcrypt.compare(cred.password, row.password_hash);
+      if (isValid) {
+        console.log(`✅ Hash válido para ${cred.correo}`);
+      } else {
+        console.error(`❌ Hash inválido para ${cred.correo}`);
+      }
+    }
+  } catch (error) {
+    console.error("[verify-passwords] Error durante la validación:", error);
+    process.exitCode = 1;
+  } finally {
+    db.close();
+  }
+});


### PR DESCRIPTION
## Summary
- align the usuarios schema with the password_hash column expected by the Next.js backend
- seed the default users with freshly generated bcrypt hashes for their known credentials
- add a verification script and npm task to assert seeded hashes match the intended passwords

## Testing
- not run (missing sqlite3/bcryptjs dependencies in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_69099ab92a8c8327abb201b1adfc9097