### PR TITLE
Fix cookie retrieval for async Next.js cookies API

### DIFF
--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -10,7 +10,8 @@ import { getUserById } from "./db";
 export async function getUserFromSession() {
   try {
     // Lee la cookie de la request actual (solo en servidor)
-    const cookie = cookies().get("user_id");
+    const cookieStore = await cookies();
+    const cookie = cookieStore.get("user_id");
 
     if (!cookie?.value) {
       console.warn("[auth] No hay cookie de sesión user_id");


### PR DESCRIPTION
## Summary
- await the Next.js cookies helper before reading the user_id cookie
- keep the existing session lookup logic intact while ensuring type compatibility

## Testing
- npm run lint (fails: Invalid project directory provided, no such directory: /workspace/agenda-inteligente/frontend/lint)

------
https://chatgpt.com/codex/tasks/task_e_690bf0fe145c8327baf27c3065c7e0c6