### PR TITLE
Fix user session retrieval in users API route

### DIFF
--- a/frontend/app/api/users/route.ts
+++ b/frontend/app/api/users/route.ts
@@ -4,31 +4,38 @@ import { getUserById } from "@/lib/db";
 
 export async function GET() {
   try {
-    // ✅ Obtener encabezados de la petición
     const headerList = headers();
+    const cookieHeader = headerList.get("cookie") ?? "";
 
-    // 🧠 Leer la cookie "user_id" manualmente
-    const cookieHeader = headerList.get("cookie");
-    const match = cookieHeader?.match(/user_id=([^;]+)/);
-    const userId = match ? Number(match[1]) : null;
+    const userIdCookie = cookieHeader
+      .split(";")
+      .map((cookie) => cookie.trim())
+      .find((cookie) => cookie.startsWith("user_id="));
 
-    if (!userId) {
+    if (!userIdCookie) {
+      return NextResponse.json({ error: "No session" }, { status: 401 });
+    }
+
+    const userIdValue = userIdCookie.substring("user_id=".length);
+    const userId = Number.parseInt(userIdValue, 10);
+
+    if (!Number.isFinite(userId)) {
       return NextResponse.json({ error: "No session" }, { status: 401 });
     }
 
     const user = await getUserById(userId);
+
     if (!user) {
       return NextResponse.json({ error: "User not found" }, { status: 404 });
     }
 
-    // ✅ Devolver solo lo necesario
     return NextResponse.json({
       id: user.id,
       nombre: user.nombre,
       correo: user.correo,
     });
-  } catch (err) {
-    console.error("[GET /api/users]", err);
+  } catch (error) {
+    console.error("[GET /api/users]", error);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
 }


### PR DESCRIPTION
## Summary
- parse the user_id cookie from request headers using the App Router headers helper
- handle missing or invalid session cookies with a 401 response
- return 404 for missing users and wrap logic in try/catch for stability

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690bf9e3dc888327bc8e1572c44335da