### PR TITLE
Fix /api/users cookie handling and greet user on inicio

### DIFF
--- a/frontend/app/(panel)/inicio/page.tsx
+++ b/frontend/app/(panel)/inicio/page.tsx
@@ -22,7 +22,7 @@ export default function InicioPage() {
   const [fecha, setFecha] = useState("");
   const [tareas, setTareas] = useState(0);
   const [eventos, setEventos] = useState(0);
-  const [nombre, setNombre] = useState<string>("usuario");
+  const [nombre, setNombre] = useState<string>("Usuario");
 
   useEffect(() => {
     // 📅 Fecha actual
@@ -42,14 +42,18 @@ export default function InicioPage() {
     const fetchUser = async () => {
       try {
         const res = await fetch("/api/users");
-        if (res.ok) {
-          const data = await res.json();
-          setNombre(data.nombre || "usuario");
-        } else {
+
+        if (!res.ok) {
           console.warn("No se pudo obtener el usuario:", res.status);
+          setNombre("Usuario");
+          return;
         }
+
+        const data = await res.json();
+        setNombre(data?.nombre ? String(data.nombre) : "Usuario");
       } catch (err) {
         console.error("Error al obtener el usuario:", err);
+        setNombre("Usuario");
       }
     };
 
@@ -60,9 +64,7 @@ export default function InicioPage() {
     <div className="flex flex-col lg:flex-row gap-6 p-6">
       {/* Sección izquierda */}
       <div className="flex-1">
-        <h1 className="text-3xl font-semibold mb-1">
-          Hola, {nombre.charAt(0).toUpperCase() + nombre.slice(1)} 👋
-        </h1>
+        <h1 className="text-3xl font-semibold mb-1">Hola, {nombre} 👋</h1>
         <p className="text-gray-600 mb-6">
           Hoy es {fecha}. Tienes{" "}
           <span className="font-medium">{tareas}</span> tareas y{" "}

--- a/frontend/app/api/users/route.ts
+++ b/frontend/app/api/users/route.ts
@@ -1,23 +1,17 @@
-import { headers } from "next/headers";
+import { cookies } from "next/headers";
 import { NextResponse } from "next/server";
 import { getUserById } from "@/lib/db";
 
 export async function GET() {
   try {
-    const headerList = headers();
-    const cookieHeader = headerList.get("cookie") ?? "";
+    const cookieStore = cookies();
+    const userIdCookie = cookieStore.get("user_id");
 
-    const userIdCookie = cookieHeader
-      .split(";")
-      .map((cookie) => cookie.trim())
-      .find((cookie) => cookie.startsWith("user_id="));
-
-    if (!userIdCookie) {
+    if (!userIdCookie?.value) {
       return NextResponse.json({ error: "No session" }, { status: 401 });
     }
 
-    const userIdValue = userIdCookie.substring("user_id=".length);
-    const userId = Number.parseInt(userIdValue, 10);
+    const userId = Number.parseInt(userIdCookie.value, 10);
 
     if (!Number.isFinite(userId)) {
       return NextResponse.json({ error: "No session" }, { status: 401 });


### PR DESCRIPTION
## Summary
- use Next.js cookies helper in the /api/users route to read the user_id session cookie safely
- ensure the inicio dashboard fetch handles API errors and falls back to a default display name
- display the authenticated user name directly in the greeting headline

## Testing
- npm run lint (fails: Invalid project directory provided, no such directory: /workspace/agenda-inteligente/frontend/lint)


------
https://chatgpt.com/codex/tasks/task_e_690bfbd86ba483278777a3c7bef91902