### PR TITLE
Show authenticated user name on dashboard greeting

### DIFF
--- a/frontend/app/(panel)/inicio/page.tsx
+++ b/frontend/app/(panel)/inicio/page.tsx
@@ -22,7 +22,7 @@ export default function InicioPage() {
   const [fecha, setFecha] = useState("");
   const [tareas, setTareas] = useState(0);
   const [eventos, setEventos] = useState(0);
-  const [nombre, setNombre] = useState<string>("Usuario");
+  const [nombre, setNombre] = useState<string>("invitado");
 
   useEffect(() => {
     // 📅 Fecha actual
@@ -41,19 +41,27 @@ export default function InicioPage() {
     // 🧠 Obtener nombre real desde /api/users
     const fetchUser = async () => {
       try {
-        const res = await fetch("/api/users");
+        const res = await fetch("/api/users", {
+          method: "GET",
+          credentials: "include",
+        });
 
         if (!res.ok) {
+          if (res.status === 401 || res.status === 404) {
+            setNombre("invitado");
+            return;
+          }
+
           console.warn("No se pudo obtener el usuario:", res.status);
-          setNombre("Usuario");
+          setNombre("invitado");
           return;
         }
 
-        const data = await res.json();
-        setNombre(data?.nombre ? String(data.nombre) : "Usuario");
+        const data: { nombre?: string | null } = await res.json();
+        setNombre(data?.nombre ? String(data.nombre) : "invitado");
       } catch (err) {
         console.error("Error al obtener el usuario:", err);
-        setNombre("Usuario");
+        setNombre("invitado");
       }
     };
 

--- a/frontend/app/api/users/route.ts
+++ b/frontend/app/api/users/route.ts
@@ -27,6 +27,7 @@ export async function GET() {
       id: user.id,
       nombre: user.nombre,
       correo: user.correo,
+      zona_horaria: user.zona_horaria ?? null,
     });
   } catch (error) {
     console.error("[GET /api/users]", error);

--- a/frontend/lib/db.ts
+++ b/frontend/lib/db.ts
@@ -88,6 +88,7 @@ export interface PublicUser {
   id: number;
   nombre: string;
   correo: string;
+  zona_horaria?: string | null;
 }
 
 //
@@ -96,7 +97,7 @@ export async function getUserById(
   id: number
 ): Promise<PublicUser | undefined> {
   return getQuery<PublicUser>(
-    "SELECT id, nombre, correo FROM usuarios WHERE id = ?",
+    "SELECT id, nombre, correo, zona_horaria FROM usuarios WHERE id = ?",
     [id]
   );
 }


### PR DESCRIPTION
## Summary
- load the signed-in user name on the /inicio dashboard greeting and fall back to "invitado" when unauthenticated
- request the user API with credentials and surface the zona_horaria field from the database so the endpoint returns the full user payload

## Testing
- npm run lint *(fails: Invalid project directory provided, no such directory: /workspace/agenda-inteligente/frontend/lint)*

------
https://chatgpt.com/codex/tasks/task_e_690bfdf9dec0832790455f4e8488e955