### PR TITLE
Add Next.js register API endpoint and update signup flow

### DIFF
--- a/frontend/app/(auth)/register/page.tsx
+++ b/frontend/app/(auth)/register/page.tsx
@@ -5,14 +5,10 @@ import Link from "next/link";
 import { FormEvent, useState } from "react";
 
 // Pantalla de registro de personas usuarias con manejo de estados y comunicación con la API.
-interface RegisterResponse {
-  ok: boolean;
-  message?: string;
-  usuario?: {
-    id: number;
-    nombre: string;
-    correo: string;
-  };
+interface RegisterSuccessResponse {
+  id: number;
+  name: string;
+  email: string;
 }
 
 export default function RegisterPage() {
@@ -35,17 +31,33 @@ export default function RegisterPage() {
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ nombre, correo, contraseña: password }),
+        body: JSON.stringify({
+          name: nombre,
+          email: correo,
+          password,
+        }),
       });
 
-      const data = (await response.json()) as RegisterResponse;
+      const data = (await response.json()) as
+        | RegisterSuccessResponse
+        | { error?: string };
 
-      if (!response.ok || !data.ok) {
-        setError(data.message ?? "No fue posible registrar al usuario");
+      if (!response.ok) {
+        const errorMessage =
+          (data as { error?: string })?.error ??
+          (response.status === 400
+            ? "Faltan datos obligatorios."
+            : response.status === 409
+            ? "El correo electrónico ya está registrado."
+            : "No fue posible registrar al usuario.");
+        setError(errorMessage);
         return;
       }
 
+      const user = data as RegisterSuccessResponse;
+
       setSuccessMessage("Tu cuenta fue creada exitosamente. ¡Ahora puedes iniciar sesión!");
+      console.info("Usuario registrado", user);
       setNombre("");
       setCorreo("");
       setPassword("");

--- a/frontend/app/api/register/route.ts
+++ b/frontend/app/api/register/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createUser, getUserByEmail } from "@/lib/db";
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json().catch(() => null);
+
+    const name =
+      typeof body?.name === "string" ? body.name.trim() : "";
+    const emailRaw =
+      typeof body?.email === "string" ? body.email.trim() : "";
+    const password =
+      typeof body?.password === "string" ? body.password : "";
+
+    if (!name || !emailRaw || !password) {
+      return NextResponse.json(
+        { error: "Nombre, correo electrónico y contraseña son obligatorios." },
+        { status: 400 }
+      );
+    }
+
+    const email = emailRaw.toLowerCase();
+
+    const existingUser = await getUserByEmail(email);
+    if (existingUser) {
+      return NextResponse.json(
+        { error: "El correo electrónico ya está registrado." },
+        { status: 409 }
+      );
+    }
+
+    const user = await createUser(name, email, password);
+
+    return NextResponse.json(
+      {
+        id: user.id,
+        name: user.nombre,
+        email: user.correo,
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    console.error("[register] Error al crear usuario", error);
+    return NextResponse.json(
+      { error: "Error interno del servidor" },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add the App Router handler for POST /api/register that validates input, hashes passwords, and returns the new user
- reuse the shared SQLite helpers to enforce unique emails and log register errors with a consistent prefix
- update the signup form to send the expected payload, handle API errors, and document the database schema in the README

## Testing
- curl -s -D - -X POST http://localhost:3000/api/register -H 'Content-Type: application/json' -d '{}' (after running `npm run dev`)
- curl -s -D - -X POST http://localhost:3000/api/register -H 'Content-Type: application/json' -d '{"name":"Test User","email":"test@example.com","password":"secret123"}'
- curl -s -D - -X POST http://localhost:3000/api/register -H 'Content-Type: application/json' -d '{"name":"Test User","email":"test@example.com","password":"secret123"}'

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911223ecc108327bc8f4f6dc6140c22)