### PR TITLE
Fix session cookie handling for authenticated greeting

### DIFF
--- a/frontend/app/(auth)/login/page.tsx
+++ b/frontend/app/(auth)/login/page.tsx
@@ -10,10 +10,10 @@ import { FormEvent, useState } from "react";
 interface LoginResponse {
   ok: boolean;
   message?: string;
-  usuario?: {
+  user?: {
     id: number;
-    nombre: string;
-    correo: string;
+    name: string;
+    email: string;
   };
 }
 
@@ -67,17 +67,17 @@ export default function LoginPage() {
         return;
       }
 
-      if (!data.usuario) {
+      if (!data.user) {
         // Validamos que el backend haya retornado la información necesaria del usuario autenticado.
         setError("No se pudo recuperar la información de la cuenta.");
         return;
       }
 
       // Guardamos la información del usuario en localStorage para recordar la sesión.
-      window.localStorage.setItem("userData", JSON.stringify(data.usuario));
+      window.localStorage.setItem("userData", JSON.stringify(data.user));
 
       // Mostramos un mensaje de bienvenida antes de enviar a la persona usuaria al panel.
-      setSuccessMessage(`¡Bienvenido de nuevo, ${data.usuario?.nombre ?? ""}!`);
+      setSuccessMessage(`¡Bienvenido de nuevo, ${data.user?.name ?? ""}!`);
       setPassword("");
 
       // Redirigimos al panel principal utilizando el router del App Router.

--- a/frontend/app/(panel)/inicio/page.tsx
+++ b/frontend/app/(panel)/inicio/page.tsx
@@ -57,9 +57,9 @@ export default function InicioPage() {
           return;
         }
 
-        const data: { id?: number; nombre?: string | null; correo?: string | null } =
+        const data: { id?: number; name?: string | null; email?: string | null } =
           await res.json();
-        setNombre(data?.nombre ? String(data.nombre) : "invitado");
+        setNombre(data?.name ? String(data.name) : "invitado");
       } catch (err) {
         console.error("Error al obtener el usuario:", err);
         setNombre("invitado");

--- a/frontend/app/api/login/route.ts
+++ b/frontend/app/api/login/route.ts
@@ -40,15 +40,25 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Éxito: devolver información pública del usuario
-    return NextResponse.json({
+    // Éxito: crear cookie de sesión y devolver información pública del usuario
+    const response = NextResponse.json({
       ok: true,
-      usuario: {
+      user: {
         id: user.id,
-        nombre: user.nombre,
-        correo: user.correo,
+        name: user.nombre,
+        email: user.correo,
       },
     });
+
+    response.cookies.set("user_id", String(user.id), {
+      httpOnly: true,
+      sameSite: "lax",
+      path: "/",
+      secure: process.env.NODE_ENV === "production",
+      maxAge: 60 * 60 * 24 * 7, // 7 días
+    });
+
+    return response;
   } catch (error) {
     console.error("Error en el inicio de sesión:", error);
 

--- a/frontend/app/api/me/route.ts
+++ b/frontend/app/api/me/route.ts
@@ -9,5 +9,5 @@ export async function GET() {
     return NextResponse.json({ error: "No autenticado" }, { status: 401 });
   }
 
-  return NextResponse.json({ nombre: user.nombre });
+  return NextResponse.json({ id: user.id, name: user.nombre, email: user.correo });
 }

--- a/frontend/app/api/user/route.ts
+++ b/frontend/app/api/user/route.ts
@@ -10,7 +10,7 @@ export async function GET() {
     }
 
     const { id, nombre, correo } = user;
-    return NextResponse.json({ id, nombre, correo });
+    return NextResponse.json({ id, name: nombre, email: correo });
   } catch (error) {
     console.error("[GET /api/user]", error);
     return NextResponse.json(


### PR DESCRIPTION
## Summary
- set the login route to set the `user_id` httpOnly cookie and return the normalized user payload
- ensure the session-aware APIs expose `{ id, name, email }` and share the same cookie-backed lookup helper
- update the dashboard greeting and docs to rely on the authenticated session response structure

## Testing
- npm run lint *(fails: Invalid project directory provided, no such directory: /workspace/agenda-inteligente/frontend/lint)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911273274d08327a1d32857e110d38e)