### PR TITLE
Implementar API y calendario para eventos internos

### DIFF
--- a/frontend/app/(panel)/inicio/page.tsx
+++ b/frontend/app/(panel)/inicio/page.tsx
@@ -1,28 +1,31 @@
 "use client";
-import { useEffect, useState } from "react";
+import dynamic from "next/dynamic";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import dayGridPlugin from "@fullcalendar/daygrid";
+import interactionPlugin from "@fullcalendar/interaction";
+import "@fullcalendar/core/index.css";
+import "@fullcalendar/daygrid/index.css";
 
-function MiniCalendar() {
-  const now = new Date();
-  const month = now.toLocaleString("es-ES", { month: "long" });
-  const year = now.getFullYear();
+const FullCalendar = dynamic(() => import("@fullcalendar/react"), {
+  ssr: false,
+});
 
-  return (
-    <div className="p-4 bg-white rounded-xl shadow-sm border border-gray-200">
-      <h2 className="text-lg font-semibold mb-2 capitalize">
-        {month} {year}
-      </h2>
-      <div className="text-gray-500 text-sm">
-        (Calendario próximamente 📅)
-      </div>
-    </div>
-  );
+interface EventoCalendario {
+  id: string;
+  title: string;
+  start: string;
+  end: string;
 }
 
 export default function InicioPage() {
   const [fecha, setFecha] = useState("");
   const [tareas, setTareas] = useState(0);
-  const [eventos, setEventos] = useState(0);
+  const [eventosHoy, setEventosHoy] = useState(0);
   const [nombre, setNombre] = useState<string>("invitado");
+  const [eventosCalendario, setEventosCalendario] = useState<EventoCalendario[]>(
+    []
+  );
+  const [cargandoEventos, setCargandoEventos] = useState(true);
 
   useEffect(() => {
     // 📅 Fecha actual
@@ -36,7 +39,6 @@ export default function InicioPage() {
     setFecha(hoy.toLocaleDateString("es-ES", opciones));
 
     setTareas(3);
-    setEventos(2);
 
     // 🧠 Obtener nombre real desde /api/user
     const fetchUser = async () => {
@@ -69,6 +71,100 @@ export default function InicioPage() {
     fetchUser();
   }, []);
 
+  const cargarEventos = useCallback(async () => {
+    try {
+      setCargandoEventos(true);
+      const respuesta = await fetch("/api/events", {
+        method: "GET",
+        credentials: "include",
+      });
+
+      if (!respuesta.ok) {
+        if (respuesta.status === 401) {
+          setEventosHoy(0);
+          setEventosCalendario([]);
+          return;
+        }
+        throw new Error(`Error ${respuesta.status}`);
+      }
+
+      const data: { eventos?: any[] } = await respuesta.json();
+      const eventos = Array.isArray(data.eventos) ? data.eventos : [];
+
+      const eventosMapeados: EventoCalendario[] = eventos.map((evento) => ({
+        id: String(evento.id),
+        title: evento.titulo ?? "(Sin título)",
+        start: evento.inicio,
+        end: evento.fin,
+      }));
+
+      const hoy = new Date();
+      const eventosDelDia = eventosMapeados.filter((evento) => {
+        if (!evento.start) return false;
+        const fechaInicio = new Date(evento.start);
+        return fechaInicio.toDateString() === hoy.toDateString();
+      }).length;
+
+      setEventosHoy(eventosDelDia);
+      setEventosCalendario(eventosMapeados);
+    } catch (error) {
+      console.error("Error al cargar eventos:", error);
+      setEventosHoy(0);
+      setEventosCalendario([]);
+    } finally {
+      setCargandoEventos(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    cargarEventos();
+  }, [cargarEventos]);
+
+  const manejarCreacionRapida = useCallback(
+    async (info: any) => {
+      const titulo = window.prompt(
+        `Nuevo evento para el ${info.dateStr}. Ingresa un título:`
+      );
+
+      if (!titulo) return;
+
+      const inicio = info.dateStr.includes("T")
+        ? info.dateStr
+        : `${info.dateStr}T09:00:00`;
+      const fin = info.dateStr.includes("T")
+        ? info.dateStr
+        : `${info.dateStr}T10:00:00`;
+
+      try {
+        const respuesta = await fetch("/api/events", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          credentials: "include",
+          body: JSON.stringify({
+            titulo,
+            inicio,
+            fin,
+            tipo: "personal",
+          }),
+        });
+
+        if (!respuesta.ok) {
+          throw new Error(`Error ${respuesta.status}`);
+        }
+
+        await cargarEventos();
+      } catch (error) {
+        console.error("No se pudo crear el evento:", error);
+        window.alert("No fue posible crear el evento. Intenta nuevamente.");
+      }
+    },
+    [cargarEventos]
+  );
+
+  const plugins = useMemo(() => [dayGridPlugin, interactionPlugin], []);
+
   return (
     <div className="flex flex-col lg:flex-row gap-6 p-6">
       {/* Sección izquierda */}
@@ -77,18 +173,42 @@ export default function InicioPage() {
         <p className="text-gray-600 mb-6">
           Hoy es {fecha}. Tienes{" "}
           <span className="font-medium">{tareas}</span> tareas y{" "}
-          <span className="font-medium">{eventos}</span> eventos para hoy.
+          <span className="font-medium">{eventosHoy}</span> eventos para hoy.
         </p>
 
-        <div className="p-6 bg-blue-50 border border-blue-200 rounded-2xl text-blue-800">
-          📆 Aquí podrás ver un resumen de tu día. Muy pronto añadiremos tus
-          próximas actividades.
+        <div className="p-6 bg-white border border-gray-200 rounded-2xl shadow-sm">
+          <h2 className="text-xl font-semibold mb-4">
+            Calendario interno de tus eventos
+          </h2>
+          {cargandoEventos ? (
+            <p className="text-gray-500">Cargando tus eventos...</p>
+          ) : (
+            <FullCalendar
+              plugins={plugins}
+              initialView="dayGridMonth"
+              locale="es"
+              events={eventosCalendario}
+              height="auto"
+              dateClick={manejarCreacionRapida}
+              headerToolbar={{
+                start: "title",
+                center: "",
+                end: "prev,next today",
+              }}
+            />
+          )}
         </div>
       </div>
 
       {/* Sección derecha */}
       <div className="w-full lg:w-1/3">
-        <MiniCalendar />
+        <div className="p-4 bg-white rounded-xl shadow-sm border border-gray-200">
+          <h2 className="text-lg font-semibold mb-2">Resumen diario</h2>
+          <p className="text-gray-600 text-sm">
+            Crea tus eventos personales directamente desde el calendario y
+            visualízalos aquí mismo.
+          </p>
+        </div>
       </div>
     </div>
   );

--- a/frontend/app/api/events/[id]/route.ts
+++ b/frontend/app/api/events/[id]/route.ts
@@ -1,0 +1,164 @@
+import { NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { getQuery, runQuery } from "@/lib/db";
+
+interface EventoInternoRow {
+  id: number;
+  id_usuario: number;
+  titulo: string;
+  descripcion: string | null;
+  inicio: string;
+  fin: string;
+  ubicacion: string | null;
+  tipo: "personal" | "equipo" | "otro";
+  recordatorio: number;
+  creado_en: string;
+}
+
+async function obtenerUsuarioAutenticado(): Promise<number | null> {
+  const cookieStore = await cookies();
+  const cookie = cookieStore.get("user_id");
+
+  if (!cookie?.value) return null;
+
+  const userId = Number(cookie.value);
+  if (!Number.isFinite(userId)) return null;
+
+  return userId;
+}
+
+async function obtenerEventoDelUsuario(
+  id: number,
+  userId: number
+): Promise<EventoInternoRow | null> {
+  const evento = await getQuery<EventoInternoRow>(
+    "SELECT id, id_usuario, titulo, descripcion, inicio, fin, ubicacion, tipo, recordatorio, creado_en FROM eventos_internos WHERE id = ? AND id_usuario = ?",
+    [id, userId]
+  );
+
+  return evento ?? null;
+}
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const userId = await obtenerUsuarioAutenticado();
+    if (!userId) {
+      return NextResponse.json({ error: "No autenticado" }, { status: 401 });
+    }
+
+    const id = Number(params.id);
+    if (!Number.isFinite(id)) {
+      return NextResponse.json(
+        { error: "Identificador de evento inválido" },
+        { status: 400 }
+      );
+    }
+
+    const evento = await obtenerEventoDelUsuario(id, userId);
+    if (!evento) {
+      return NextResponse.json(
+        { error: "Evento no encontrado" },
+        { status: 404 }
+      );
+    }
+
+    const body = await request.json();
+
+    const titulo =
+      typeof body.titulo === "string" && body.titulo.trim()
+        ? body.titulo.trim()
+        : evento.titulo;
+    const descripcion =
+      typeof body.descripcion === "string"
+        ? body.descripcion
+        : evento.descripcion;
+    const inicio = body.inicio ?? evento.inicio;
+    const fin = body.fin ?? evento.fin;
+    const ubicacion =
+      typeof body.ubicacion === "string"
+        ? body.ubicacion
+        : evento.ubicacion;
+
+    const tiposPermitidos = new Set(["personal", "equipo", "otro"]);
+    const tipo = tiposPermitidos.has(body.tipo) ? body.tipo : evento.tipo;
+
+    const recordatorio = Number.isFinite(Number(body.recordatorio))
+      ? Number(body.recordatorio)
+      : evento.recordatorio;
+
+    if (!inicio || !fin) {
+      return NextResponse.json(
+        { error: "Las fechas de inicio y fin son obligatorias" },
+        { status: 400 }
+      );
+    }
+
+    await runQuery(
+      "UPDATE eventos_internos SET titulo = ?, descripcion = ?, inicio = ?, fin = ?, ubicacion = ?, tipo = ?, recordatorio = ? WHERE id = ? AND id_usuario = ?",
+      [
+        titulo,
+        descripcion,
+        inicio,
+        fin,
+        ubicacion,
+        tipo,
+        recordatorio,
+        id,
+        userId,
+      ]
+    );
+
+    return NextResponse.json({ message: "Evento actualizado correctamente" });
+  } catch (error) {
+    console.error("[PUT /api/events/:id]", error);
+    return NextResponse.json(
+      { error: "Error interno del servidor" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const userId = await obtenerUsuarioAutenticado();
+    if (!userId) {
+      return NextResponse.json({ error: "No autenticado" }, { status: 401 });
+    }
+
+    const id = Number(params.id);
+    if (!Number.isFinite(id)) {
+      return NextResponse.json(
+        { error: "Identificador de evento inválido" },
+        { status: 400 }
+      );
+    }
+
+    const evento = await obtenerEventoDelUsuario(id, userId);
+    if (!evento) {
+      return NextResponse.json(
+        { error: "Evento no encontrado" },
+        { status: 404 }
+      );
+    }
+
+    await runQuery(
+      "DELETE FROM eventos_internos WHERE id = ? AND id_usuario = ?",
+      [id, userId]
+    );
+
+    return NextResponse.json({ message: "Evento eliminado correctamente" });
+  } catch (error) {
+    console.error("[DELETE /api/events/:id]", error);
+    return NextResponse.json(
+      { error: "Error interno del servidor" },
+      { status: 500 }
+    );
+  }
+}
+

--- a/frontend/app/api/events/route.ts
+++ b/frontend/app/api/events/route.ts
@@ -1,0 +1,120 @@
+import { NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { allQuery, runQuery } from "@/lib/db";
+
+interface EventoInternoRow {
+  id: number;
+  id_usuario: number;
+  titulo: string;
+  descripcion: string | null;
+  inicio: string;
+  fin: string;
+  ubicacion: string | null;
+  tipo: "personal" | "equipo" | "otro";
+  recordatorio: number;
+  creado_en: string;
+}
+
+async function obtenerUsuarioAutenticado(): Promise<number | null> {
+  const cookieStore = await cookies();
+  const cookie = cookieStore.get("user_id");
+
+  if (!cookie?.value) {
+    return null;
+  }
+
+  const userId = Number(cookie.value);
+  if (!Number.isFinite(userId)) {
+    return null;
+  }
+
+  return userId;
+}
+
+export async function GET() {
+  try {
+    const userId = await obtenerUsuarioAutenticado();
+
+    if (!userId) {
+      return NextResponse.json({ error: "No autenticado" }, { status: 401 });
+    }
+
+    const eventos = await allQuery<EventoInternoRow>(
+      "SELECT id, id_usuario, titulo, descripcion, inicio, fin, ubicacion, tipo, recordatorio, creado_en FROM eventos_internos WHERE id_usuario = ? ORDER BY inicio ASC",
+      [userId]
+    );
+
+    return NextResponse.json({ eventos });
+  } catch (error) {
+    console.error("[GET /api/events]", error);
+    return NextResponse.json(
+      { error: "Error interno del servidor" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const userId = await obtenerUsuarioAutenticado();
+
+    if (!userId) {
+      return NextResponse.json({ error: "No autenticado" }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const {
+      titulo,
+      descripcion = null,
+      inicio,
+      fin,
+      ubicacion = null,
+      tipo = "personal",
+      recordatorio = 0,
+    } = body ?? {};
+
+    if (!titulo || typeof titulo !== "string") {
+      return NextResponse.json(
+        { error: "El título es obligatorio" },
+        { status: 400 }
+      );
+    }
+
+    if (!inicio || !fin) {
+      return NextResponse.json(
+        { error: "Las fechas de inicio y fin son obligatorias" },
+        { status: 400 }
+      );
+    }
+
+    const tiposPermitidos = new Set(["personal", "equipo", "otro"]);
+    const tipoEvento = tiposPermitidos.has(tipo) ? tipo : "personal";
+
+    const recordatorioValor = Number(recordatorio) || 0;
+
+    const insertResult = await runQuery(
+      "INSERT INTO eventos_internos (id_usuario, titulo, descripcion, inicio, fin, ubicacion, tipo, recordatorio) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+      [
+        userId,
+        titulo.trim(),
+        descripcion,
+        inicio,
+        fin,
+        ubicacion,
+        tipoEvento,
+        recordatorioValor,
+      ]
+    );
+
+    const id = Number(insertResult.lastID);
+
+    return NextResponse.json({ id, message: "Evento creado correctamente" });
+  } catch (error) {
+    console.error("[POST /api/events]", error);
+    return NextResponse.json(
+      { error: "Error interno del servidor" },
+      { status: 500 }
+    );
+  }
+}
+

--- a/frontend/lib/db.ts
+++ b/frontend/lib/db.ts
@@ -73,6 +73,16 @@ export function getQuery<T>(
   });
 }
 
+export function allQuery<T>(sql: string, params: unknown[] = []): Promise<T[]> {
+  const db = ensureDatabase();
+  return new Promise((resolve, reject) => {
+    db.all(sql, params, (err, rows: T[]) => {
+      if (err) reject(err);
+      else resolve(rows);
+    });
+  });
+}
+
 //
 // --- INTERFACES ---
 export interface UsuarioRow {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,10 @@
   "packages": {
     "": {
       "dependencies": {
+        "@fullcalendar/core": "^6.1.15",
+        "@fullcalendar/daygrid": "^6.1.15",
+        "@fullcalendar/interaction": "^6.1.15",
+        "@fullcalendar/react": "^6.1.15",
         "next": "^16.0.1",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,9 @@
 {
   "dependencies": {
+    "@fullcalendar/core": "^6.1.15",
+    "@fullcalendar/daygrid": "^6.1.15",
+    "@fullcalendar/interaction": "^6.1.15",
+    "@fullcalendar/react": "^6.1.15",
     "next": "^16.0.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"


### PR DESCRIPTION
## Summary
- agregar utilitario `allQuery` y exponer endpoints REST para eventos internos protegidos por la cookie `user_id`
- mostrar los eventos del usuario en /inicio usando FullCalendar con creación rápida desde la vista mensual
- declarar las dependencias de FullCalendar necesarias en el proyecto

## Testing
- npm install @fullcalendar/react @fullcalendar/core @fullcalendar/daygrid @fullcalendar/interaction *(falla: 403 Forbidden en el registro de npm)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69113137f5048327bc88b66a2f61931f)