### PR TITLE
Add Google Calendar synchronization endpoints

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -51,6 +51,37 @@ CREATE TABLE IF NOT EXISTS eventos_externos (
 );
 
 -- ============================================================
+-- Tabla: google_tokens (credenciales OAuth de Google Calendar)
+-- ============================================================
+CREATE TABLE IF NOT EXISTS google_tokens (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id       INTEGER NOT NULL,
+    access_token  TEXT,
+    refresh_token TEXT,
+    token_expiry  DATETIME,
+    scope         TEXT,
+    created_at    DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at    DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES usuarios(id) ON DELETE CASCADE
+);
+
+-- ============================================================
+-- Tabla: events (eventos sincronizados desde proveedores externos)
+-- ============================================================
+CREATE TABLE IF NOT EXISTS events (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id      INTEGER NOT NULL,
+    google_id    TEXT UNIQUE,
+    title        TEXT,
+    description  TEXT,
+    start_time   DATETIME,
+    end_time     DATETIME,
+    created_at   DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at   DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES usuarios(id) ON DELETE CASCADE
+);
+
+-- ============================================================
 -- 4. Tabla: equipos
 -- ============================================================
 CREATE TABLE IF NOT EXISTS equipos (

--- a/frontend/app/api/google/auth/route.ts
+++ b/frontend/app/api/google/auth/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { crearClienteOAuth, obtenerScopes } from "@/lib/google";
+
+/**
+ * Maneja la redirección inicial hacia Google para iniciar el flujo OAuth2.
+ */
+export async function GET() {
+  try {
+    const oauthClient = crearClienteOAuth();
+    const scopes = obtenerScopes();
+
+    const authUrl = oauthClient.generateAuthUrl({
+      access_type: "offline",
+      scope: scopes,
+      prompt: "consent",
+    });
+
+    return NextResponse.redirect(authUrl);
+  } catch (error) {
+    console.error("[GET /api/google/auth]", error);
+    return NextResponse.json(
+      {
+        error:
+          "No fue posible iniciar la autenticación con Google. Verifica la configuración del servidor.",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/app/api/google/callback/route.ts
+++ b/frontend/app/api/google/callback/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+import { crearClienteOAuth, guardarTokens } from "@/lib/google";
+
+const USER_ID = 1;
+
+/**
+ * Gestiona la respuesta de Google, intercambiando el código por tokens y almacenándolos.
+ */
+export async function GET(request: NextRequest) {
+  const code = request.nextUrl.searchParams.get("code");
+
+  if (!code) {
+    return NextResponse.json(
+      { error: "No se recibió el código de autorización de Google" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const oauthClient = crearClienteOAuth();
+    const { tokens } = await oauthClient.getToken(code);
+
+    await guardarTokens(USER_ID, tokens);
+
+    const maskedToken = tokens.access_token
+      ? `${tokens.access_token.slice(0, 4)}...`
+      : "sin-token";
+    console.log(`✅ Tokens de Google almacenados para el usuario ${USER_ID} (${maskedToken})`);
+
+    const redirectUrl = new URL("/inicio", request.nextUrl.origin);
+    return NextResponse.redirect(redirectUrl);
+  } catch (error) {
+    console.error("[GET /api/google/callback]", error);
+    return NextResponse.json(
+      {
+        error:
+          "Ocurrió un problema al procesar la respuesta de Google. Intenta nuevamente en unos minutos.",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/app/api/google/events/route.ts
+++ b/frontend/app/api/google/events/route.ts
@@ -1,0 +1,100 @@
+import { NextResponse } from "next/server";
+import { google } from "googleapis";
+import {
+  construirCredencialesDesdeFila,
+  crearClienteOAuth,
+  guardarEventoSincronizado,
+  guardarTokens,
+  obtenerTokensPorUsuario,
+  tokenExpirado,
+} from "@/lib/google";
+
+const USER_ID = 1;
+
+/**
+ * Descarga los próximos eventos del calendario principal y los guarda en SQLite.
+ */
+export async function GET() {
+  try {
+    const tokenRow = await obtenerTokensPorUsuario(USER_ID);
+
+    if (!tokenRow) {
+      return NextResponse.json(
+        {
+          error:
+            "No se encontraron tokens almacenados. Conecta tu cuenta de Google desde /api/google/auth.",
+        },
+        { status: 404 }
+      );
+    }
+
+    let credentials = construirCredencialesDesdeFila(tokenRow);
+    const oauthClient = crearClienteOAuth(credentials);
+
+    if (tokenExpirado(tokenRow) || !credentials?.access_token) {
+      if (!tokenRow.refresh_token) {
+        return NextResponse.json(
+          {
+            error:
+              "El token expiró y no hay refresh_token disponible. Repite el proceso de autenticación.",
+          },
+          { status: 401 }
+        );
+      }
+
+      const refreshed = await oauthClient.refreshToken(tokenRow.refresh_token);
+      credentials = refreshed.credentials;
+
+      await guardarTokens(USER_ID, credentials);
+      oauthClient.setCredentials(credentials);
+    }
+
+    const calendar = google.calendar({ version: "v3", auth: oauthClient });
+    const response = await calendar.events.list({
+      calendarId: "primary",
+      maxResults: 20,
+      singleEvents: true,
+      orderBy: "startTime",
+      timeMin: new Date().toISOString(),
+    });
+
+    const items = response.data.items ?? [];
+    let synchronized = 0;
+
+    for (const event of items) {
+      const googleId = event.id;
+      if (!googleId) {
+        continue;
+      }
+
+      const start = event.start?.dateTime ?? event.start?.date ?? null;
+      const end = event.end?.dateTime ?? event.end?.date ?? start;
+      const title = event.summary ?? "(Sin título)";
+      const description = event.description ?? null;
+
+      await guardarEventoSincronizado({
+        userId: USER_ID,
+        googleId,
+        title,
+        description,
+        start,
+        end,
+      });
+
+      synchronized += 1;
+    }
+
+    console.log(`✅ Eventos sincronizados: ${synchronized}`);
+
+    return NextResponse.json({ ok: true, events: synchronized });
+  } catch (error) {
+    console.error("[GET /api/google/events]", error);
+    return NextResponse.json(
+      {
+        error:
+          "Ocurrió un problema al sincronizar los eventos de Google Calendar.",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/lib/google.ts
+++ b/frontend/lib/google.ts
@@ -1,0 +1,246 @@
+import { google } from "googleapis";
+import type { Credentials, OAuth2Client } from "google-auth-library";
+import { getQuery, runQuery } from "@/lib/db";
+
+/**
+ * Describe la forma de la fila almacenada en la tabla `google_tokens`.
+ */
+export interface GoogleTokenRow {
+  id: number;
+  user_id: number;
+  access_token: string | null;
+  refresh_token: string | null;
+  token_expiry: string | null;
+  scope: string | null;
+}
+
+const DEFAULT_SCOPES = [
+  "https://www.googleapis.com/auth/calendar.readonly",
+];
+
+let tablaGoogleTokensCreada = false;
+let tablaEventosCreada = false;
+
+/**
+ * Obtiene los alcances solicitados a Google a partir de las variables de entorno.
+ */
+export function obtenerScopes(): string[] {
+  const scopes = process.env.GOOGLE_SCOPES;
+
+  if (!scopes) {
+    return DEFAULT_SCOPES;
+  }
+
+  return scopes
+    .split(/[\s,]+/)
+    .map((scope) => scope.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Valida la existencia de las variables requeridas para el cliente OAuth.
+ */
+export function obtenerCredencialesDesdeEntorno(): {
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;
+} {
+  const clientId = process.env.GOOGLE_CLIENT_ID;
+  const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
+  const redirectUri = process.env.GOOGLE_REDIRECT_URI;
+
+  if (!clientId || !clientSecret || !redirectUri) {
+    throw new Error(
+      "Faltan credenciales de Google. Revisa GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET y GOOGLE_REDIRECT_URI."
+    );
+  }
+
+  return { clientId, clientSecret, redirectUri };
+}
+
+/**
+ * Construye un cliente OAuth2 listo para usarse en la integración de Google Calendar.
+ */
+export function crearClienteOAuth(tokens?: Credentials): OAuth2Client {
+  const { clientId, clientSecret, redirectUri } =
+    obtenerCredencialesDesdeEntorno();
+
+  const client = new google.auth.OAuth2(clientId, clientSecret, redirectUri);
+
+  if (tokens) {
+    client.setCredentials(tokens);
+  }
+
+  return client;
+}
+
+/**
+ * Garantiza que la tabla `google_tokens` exista antes de realizar operaciones.
+ */
+export async function asegurarTablaGoogleTokens(): Promise<void> {
+  if (tablaGoogleTokensCreada) {
+    return;
+  }
+
+  await runQuery(
+    `CREATE TABLE IF NOT EXISTS google_tokens (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER NOT NULL,
+      access_token TEXT,
+      refresh_token TEXT,
+      token_expiry DATETIME,
+      scope TEXT,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    )`
+  );
+
+  tablaGoogleTokensCreada = true;
+}
+
+/**
+ * Garantiza que exista la tabla `events` utilizada para almacenar los eventos sincronizados.
+ */
+export async function asegurarTablaEventos(): Promise<void> {
+  if (tablaEventosCreada) {
+    return;
+  }
+
+  await runQuery(
+    `CREATE TABLE IF NOT EXISTS events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER NOT NULL,
+      google_id TEXT UNIQUE,
+      title TEXT,
+      description TEXT,
+      start_time DATETIME,
+      end_time DATETIME,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      FOREIGN KEY (user_id) REFERENCES usuarios(id) ON DELETE CASCADE
+    )`
+  );
+
+  tablaEventosCreada = true;
+}
+
+/**
+ * Recupera los tokens almacenados para un usuario determinado.
+ */
+export async function obtenerTokensPorUsuario(
+  userId: number
+): Promise<GoogleTokenRow | null> {
+  await asegurarTablaGoogleTokens();
+
+  const token = await getQuery<GoogleTokenRow>(
+    "SELECT id, user_id, access_token, refresh_token, token_expiry, scope FROM google_tokens WHERE user_id = ? ORDER BY id DESC LIMIT 1",
+    [userId]
+  );
+
+  return token ?? null;
+}
+
+/**
+ * Convierte la fecha de expiración en milisegundos a un ISO string.
+ */
+export function formatearExpiracion(expiryDate?: number | null): string | null {
+  if (!expiryDate) {
+    return null;
+  }
+
+  return new Date(expiryDate).toISOString();
+}
+
+/**
+ * Guarda o actualiza los tokens recibidos desde Google.
+ */
+export async function guardarTokens(
+  userId: number,
+  tokens: Credentials
+): Promise<void> {
+  await asegurarTablaGoogleTokens();
+
+  const existente = await obtenerTokensPorUsuario(userId);
+  const tokenExpiry = formatearExpiracion(tokens.expiry_date ?? null);
+  const scope = Array.isArray(tokens.scope)
+    ? tokens.scope.join(" ")
+    : tokens.scope ?? obtenerScopes().join(" ");
+
+  const refreshToken = tokens.refresh_token ?? existente?.refresh_token ?? null;
+  const accessToken = tokens.access_token ?? existente?.access_token ?? null;
+
+  if (existente) {
+    await runQuery(
+      "UPDATE google_tokens SET access_token = ?, refresh_token = ?, token_expiry = ?, scope = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+      [accessToken, refreshToken, tokenExpiry, scope, existente.id]
+    );
+  } else {
+    await runQuery(
+      "INSERT INTO google_tokens (user_id, access_token, refresh_token, token_expiry, scope) VALUES (?, ?, ?, ?, ?)",
+      [userId, accessToken, refreshToken, tokenExpiry, scope]
+    );
+  }
+}
+
+/**
+ * Verifica si el token guardado ya expiró en base a la fecha almacenada.
+ */
+export function tokenExpirado(token: GoogleTokenRow | null): boolean {
+  if (!token?.token_expiry) {
+    return false;
+  }
+
+  const expiracion = new Date(token.token_expiry).getTime();
+  if (Number.isNaN(expiracion)) {
+    return false;
+  }
+
+  return expiracion <= Date.now();
+}
+
+/**
+ * Transforma los tokens guardados en credenciales para el cliente OAuth.
+ */
+export function construirCredencialesDesdeFila(
+  fila: GoogleTokenRow | null
+): Credentials | undefined {
+  if (!fila) {
+    return undefined;
+  }
+
+  const expiry = fila.token_expiry ? new Date(fila.token_expiry).getTime() : undefined;
+
+  return {
+    access_token: fila.access_token ?? undefined,
+    refresh_token: fila.refresh_token ?? undefined,
+    expiry_date: expiry,
+    scope: fila.scope ?? undefined,
+  };
+}
+
+/**
+ * Inserta o reemplaza un evento en la tabla local `events`.
+ */
+export async function guardarEventoSincronizado(options: {
+  userId: number;
+  googleId: string;
+  title: string | null;
+  description: string | null;
+  start: string | null;
+  end: string | null;
+}): Promise<void> {
+  await asegurarTablaEventos();
+
+  await runQuery(
+    `INSERT OR REPLACE INTO events (google_id, user_id, title, description, start_time, end_time, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)`,
+    [
+      options.googleId,
+      options.userId,
+      options.title,
+      options.description,
+      options.start,
+      options.end,
+    ]
+  );
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "@fullcalendar/interaction": "^6.1.19",
     "@fullcalendar/react": "^6.1.19",
     "bcryptjs": "^2.4.3",
+    "googleapis": "^131.0.0",
     "next": "latest",
     "react": "latest",
     "react-dom": "latest",


### PR DESCRIPTION
## Summary
- add OAuth authentication redirect, callback handling, and event sync endpoints backed by Google Calendar
- persist Google OAuth tokens and synchronized events in SQLite using a dedicated helper module
- extend the database schema to include google_tokens and events tables for calendar integration

## Testing
- npm run lint *(fails: Invalid project directory provided, no such directory: /workspace/agenda-inteligente/frontend/lint)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69123f7b252c8327a173c3abba1c56f8)