### PR TITLE
Fix Google OAuth environment credential loading

### DIFF
--- a/frontend/app/api/google/auth/route.ts
+++ b/frontend/app/api/google/auth/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { crearClienteOAuth, obtenerScopes } from "@/lib/google";
 
+export const runtime = "nodejs";
+
 /**
  * Maneja la redirección inicial hacia Google para iniciar el flujo OAuth2.
  */
@@ -13,9 +15,10 @@ export async function GET() {
       access_type: "offline",
       scope: scopes,
       prompt: "consent",
+      include_granted_scopes: true,
     });
 
-    return NextResponse.redirect(authUrl);
+    return NextResponse.redirect(authUrl, 302);
   } catch (error) {
     console.error("[GET /api/google/auth]", error);
     return NextResponse.json(

--- a/frontend/app/api/google/callback/route.ts
+++ b/frontend/app/api/google/callback/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { crearClienteOAuth, guardarTokens } from "@/lib/google";
 
+export const runtime = "nodejs";
+
 const USER_ID = 1;
 
 /**
@@ -32,7 +34,7 @@ export async function GET(request: NextRequest) {
       `ℹ️ Tokens de Google almacenados para el usuario ${USER_ID} (${maskedToken}).`,
     );
 
-    const redirectUrl = new URL("/inicio", request.nextUrl.origin);
+    const redirectUrl = new URL("/eventos", request.nextUrl.origin);
     return NextResponse.redirect(redirectUrl);
   } catch (error) {
     console.error("[GET /api/google/callback]", error);

--- a/frontend/app/api/google/debug/route.ts
+++ b/frontend/app/api/google/debug/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+
+const esCadenaValida = (valor: unknown): valor is string =>
+  typeof valor === "string" && valor.trim() !== "";
+
+export async function GET() {
+  if (process.env.NODE_ENV === "production") {
+    return NextResponse.json({ error: "No disponible" }, { status: 404 });
+  }
+
+  const runtimeActual =
+    typeof process.env.NEXT_RUNTIME === "string"
+      ? process.env.NEXT_RUNTIME
+      : "nodejs";
+
+  return NextResponse.json({
+    GOOGLE_CLIENT_ID: esCadenaValida(process.env.GOOGLE_CLIENT_ID),
+    GOOGLE_CLIENT_SECRET: esCadenaValida(process.env.GOOGLE_CLIENT_SECRET),
+    GOOGLE_REDIRECT_URI: esCadenaValida(process.env.GOOGLE_REDIRECT_URI),
+    runtime: runtimeActual,
+  });
+}


### PR DESCRIPTION
## Summary
- ensure Google OAuth configuration validates .env credentials, logs sources, and falls back to the local JSON file only when needed
- run the Google OAuth API handlers on the Node.js runtime, expand default scopes, and add a temporary debug endpoint for credential presence
- update the callback redirect target to /eventos and keep secrets out of logs

## Testing
- npm run lint *(fails: Invalid project directory provided, no such directory: /workspace/agenda-inteligente/frontend/lint)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691258299fd8832795cf610f31ce3a98)