### PR TITLE
Fix Google Calendar OAuth flow

### DIFF
--- a/frontend/app/(panel)/inicio/page.tsx
+++ b/frontend/app/(panel)/inicio/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { EventClickArg } from "@fullcalendar/core";
 import dayGridPlugin from "@fullcalendar/daygrid";
@@ -36,7 +35,6 @@ const esRegistroEvento = (value: unknown): value is Record<string, unknown> =>
   Boolean(value) && typeof value === "object";
 
 export default function InicioPage() {
-  const router = useRouter();
   const [fecha, setFecha] = useState("");
   const [tareas, setTareas] = useState(0);
   const [eventosHoy, setEventosHoy] = useState(0);
@@ -195,10 +193,32 @@ export default function InicioPage() {
   }, []);
 
   // 🔁 Inicia el flujo de autenticación con Google Calendar
-  const manejarSincronizacionGoogle = useCallback(() => {
+  const manejarSincronizacionGoogle = useCallback(async () => {
     setSincronizandoGoogle(true);
-    router.push("/api/google/auth");
-  }, [router]);
+
+    try {
+      const respuesta = await fetch("/api/google/auth");
+
+      if (!respuesta.ok) {
+        throw new Error(`Solicitud fallida: ${respuesta.status}`);
+      }
+
+      const data: unknown = await respuesta.json();
+      const url =
+        data && typeof data === "object" && "url" in data
+          ? (data as { url?: unknown }).url
+          : undefined;
+
+      if (typeof url !== "string" || !url) {
+        throw new Error("Respuesta inválida de /api/google/auth");
+      }
+
+      window.location.href = url;
+    } catch (error) {
+      console.error("No fue posible iniciar la autenticación con Google:", error);
+      setSincronizandoGoogle(false);
+    }
+  }, []);
 
   useEffect(() => {
     cargarEventos();

--- a/frontend/app/api/google/auth/route.ts
+++ b/frontend/app/api/google/auth/route.ts
@@ -18,7 +18,7 @@ export async function GET() {
       include_granted_scopes: true,
     });
 
-    return NextResponse.redirect(authUrl, 302);
+    return NextResponse.json({ url: authUrl });
   } catch (error) {
     console.error("[GET /api/google/auth]", error);
     return NextResponse.json(

--- a/frontend/lib/google.ts
+++ b/frontend/lib/google.ts
@@ -1,8 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
 
-import { google } from "googleapis";
-import type { Credentials, OAuth2Client } from "google-auth-library";
+import type { Credentials } from "google-auth-library";
+import { OAuth2Client } from "google-auth-library";
 import { getQuery, runQuery } from "@/lib/db";
 
 /**
@@ -27,10 +27,9 @@ export interface ConfiguracionOAuth {
 }
 
 const DEFAULT_SCOPES = [
-  "https://www.googleapis.com/auth/calendar.events",
-  "openid",
-  "email",
-  "profile",
+  "https://www.googleapis.com/auth/calendar",
+  "https://www.googleapis.com/auth/userinfo.email",
+  "https://www.googleapis.com/auth/userinfo.profile",
 ];
 
 const CREDENTIALS_PATH = path.join(
@@ -234,7 +233,7 @@ export function obtenerConfiguracionOAuth(): ConfiguracionOAuth {
 export function crearClienteOAuth(tokens?: Credentials): OAuth2Client {
   const { clientId, clientSecret, redirectUri } = obtenerConfiguracionOAuth();
 
-  const client = new google.auth.OAuth2(clientId, clientSecret, redirectUri);
+  const client = new OAuth2Client(clientId, clientSecret, redirectUri);
 
   if (tokens) {
     client.setCredentials(tokens);


### PR DESCRIPTION
## Summary
- create the Google OAuth2 client with the official google-auth-library using environment credentials and the required scopes
- update the auth API route to return the Google consent URL instead of redirecting directly
- adjust the dashboard sync button to request the auth URL before redirecting the browser

## Testing
- npx next lint . *(fails: command interpreted as directory because the current Next.js CLI does not recognize the `lint` subcommand in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912b63dd2b0832788f76bf86dfc6522)