### PR TITLE
Fix Google OAuth flow redirect handling

### DIFF
--- a/frontend/app/api/google/auth/route.ts
+++ b/frontend/app/api/google/auth/route.ts
@@ -1,21 +1,30 @@
-import { NextResponse } from "next/server";
-import { crearClienteOAuth, obtenerScopes } from "@/lib/google";
+import { NextRequest, NextResponse } from "next/server";
+import {
+  crearClienteOAuth,
+  obtenerRedirectUriEfectiva,
+  obtenerScopes,
+} from "@/lib/google";
 
 export const runtime = "nodejs";
 
 /**
  * Maneja la redirección inicial hacia Google para iniciar el flujo OAuth2.
  */
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
-    const client = crearClienteOAuth();
+    const redirectUri = obtenerRedirectUriEfectiva(request.nextUrl.origin);
+    const client = crearClienteOAuth({ redirectUri });
     const scopes = obtenerScopes();
     const url = client.generateAuthUrl({
       access_type: "offline",
       scope: scopes,
+      prompt: "consent",
+      include_granted_scopes: true,
+      response_type: "code",
+      redirect_uri: redirectUri,
     });
     console.log("[GoogleAuth] URL generada:", url);
-    return NextResponse.json({ url });
+    return NextResponse.json({ url, redirectUri });
   } catch (error) {
     console.error("[GoogleAuth Error]", error);
     return NextResponse.json(

--- a/frontend/app/api/google/events/route.ts
+++ b/frontend/app/api/google/events/route.ts
@@ -29,7 +29,7 @@ export async function GET() {
     }
 
     let credentials = construirCredencialesDesdeFila(tokenRow);
-    const oauthClient = crearClienteOAuth(credentials);
+    const oauthClient = crearClienteOAuth({ tokens: credentials });
 
     if (tokenExpirado(tokenRow) || !credentials?.access_token) {
       if (!tokenRow.refresh_token) {


### PR DESCRIPTION
## Summary
- normalize Google OAuth redirect URIs and expose helpers so they can follow the active request origin when needed
- ensure the auth and callback routes pass the resolved redirect URI to Google, add explicit OAuth parameters, and improve error logging
- update the events sync route to use the new OAuth client signature and request the openid scope for Google profile access

## Testing
- npm run lint *(fails: Invalid project directory provided, no such directory: /workspace/agenda-inteligente/frontend/lint)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912bbff87a48327a5af18273bda9f36)