### PR TITLE
Fix invitation handlers and user creation

### DIFF
--- a/frontend/app/api/invitaciones/[id]/aceptar/route.ts
+++ b/frontend/app/api/invitaciones/[id]/aceptar/route.ts
@@ -2,35 +2,58 @@ import { NextResponse } from "next/server";
 import { getUserFromSession } from "@/lib/auth";
 import { db } from "@/lib/db";
 
-interface Params {
-  params: {
-    id: string;
-  };
+interface InvitacionRow {
+  id: number;
+  estado: string;
 }
 
-export async function POST(_: Request, { params }: Params) {
+export async function POST(
+  _: Request,
+  context: { params: { id: string } }
+) {
   try {
     const user = await getUserFromSession();
     if (!user) {
       return NextResponse.json({ error: "No autenticado" }, { status: 401 });
     }
 
-    const invitacionId = Number(params.id);
-    if (!Number.isInteger(invitacionId)) {
+    const invitacionId = Number(context.params.id);
+    if (!Number.isInteger(invitacionId) || invitacionId <= 0) {
       return NextResponse.json({ error: "Invitación inválida" }, { status: 400 });
+    }
+
+    const invitacion = await db.get<InvitacionRow>(
+      `SELECT id, estado
+       FROM miembros_equipo
+       WHERE id = ? AND id_usuario = ?`,
+      [invitacionId, user.id]
+    );
+
+    if (!invitacion) {
+      return NextResponse.json(
+        { error: "Invitación no encontrada" },
+        { status: 404 }
+      );
+    }
+
+    if (invitacion.estado !== "pendiente") {
+      return NextResponse.json(
+        { error: "La invitación ya fue respondida" },
+        { status: 409 }
+      );
     }
 
     const update = await db.run(
       `UPDATE miembros_equipo
        SET estado = 'aceptado', respondido_en = CURRENT_TIMESTAMP
-       WHERE id = ? AND id_usuario = ? AND estado = 'pendiente'`,
+       WHERE id = ? AND id_usuario = ?`,
       [invitacionId, user.id]
     );
 
     if (!update.changes) {
       return NextResponse.json(
-        { error: "Invitación no encontrada o ya respondida" },
-        { status: 404 }
+        { error: "No se pudo actualizar la invitación" },
+        { status: 500 }
       );
     }
 

--- a/frontend/app/api/invitaciones/[id]/rechazar/route.ts
+++ b/frontend/app/api/invitaciones/[id]/rechazar/route.ts
@@ -2,35 +2,58 @@ import { NextResponse } from "next/server";
 import { getUserFromSession } from "@/lib/auth";
 import { db } from "@/lib/db";
 
-interface Params {
-  params: {
-    id: string;
-  };
+interface InvitacionRow {
+  id: number;
+  estado: string;
 }
 
-export async function POST(_: Request, { params }: Params) {
+export async function POST(
+  _: Request,
+  context: { params: { id: string } }
+) {
   try {
     const user = await getUserFromSession();
     if (!user) {
       return NextResponse.json({ error: "No autenticado" }, { status: 401 });
     }
 
-    const invitacionId = Number(params.id);
-    if (!Number.isInteger(invitacionId)) {
+    const invitacionId = Number(context.params.id);
+    if (!Number.isInteger(invitacionId) || invitacionId <= 0) {
       return NextResponse.json({ error: "Invitación inválida" }, { status: 400 });
+    }
+
+    const invitacion = await db.get<InvitacionRow>(
+      `SELECT id, estado
+       FROM miembros_equipo
+       WHERE id = ? AND id_usuario = ?`,
+      [invitacionId, user.id]
+    );
+
+    if (!invitacion) {
+      return NextResponse.json(
+        { error: "Invitación no encontrada" },
+        { status: 404 }
+      );
+    }
+
+    if (invitacion.estado !== "pendiente") {
+      return NextResponse.json(
+        { error: "La invitación ya fue respondida" },
+        { status: 409 }
+      );
     }
 
     const update = await db.run(
       `UPDATE miembros_equipo
        SET estado = 'rechazado', respondido_en = CURRENT_TIMESTAMP
-       WHERE id = ? AND id_usuario = ? AND estado = 'pendiente'`,
+       WHERE id = ? AND id_usuario = ?`,
       [invitacionId, user.id]
     );
 
     if (!update.changes) {
       return NextResponse.json(
-        { error: "Invitación no encontrada o ya respondida" },
-        { status: 404 }
+        { error: "No se pudo actualizar la invitación" },
+        { status: 500 }
       );
     }
 

--- a/frontend/app/api/usuarios/route.ts
+++ b/frontend/app/api/usuarios/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { getUserFromSession } from "@/lib/auth";
-import { db } from "@/lib/db";
+import { createUser, db, getUserByEmail } from "@/lib/db";
 
 interface UsuarioLigero {
   id: number;
@@ -25,6 +25,74 @@ export async function GET() {
     console.error("[GET /api/usuarios]", error);
     return NextResponse.json(
       { error: "No se pudieron obtener los usuarios" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json().catch(() => null);
+
+    const nombre =
+      typeof body?.nombre === "string" ? body.nombre.trim() : "";
+    const correoRaw =
+      typeof body?.correo === "string" ? body.correo.trim() : "";
+    const password =
+      typeof body?.password === "string" ? body.password : "";
+    const zonaHoraria =
+      typeof body?.zonaHoraria === "string" && body.zonaHoraria.trim()
+        ? body.zonaHoraria.trim()
+        : null;
+
+    if (!nombre || !correoRaw || !password) {
+      return NextResponse.json(
+        {
+          error:
+            "Nombre, correo electrónico y contraseña son obligatorios.",
+        },
+        { status: 400 }
+      );
+    }
+
+    const correo = correoRaw.toLowerCase();
+
+    const existing = await getUserByEmail(correo);
+    if (existing) {
+      return NextResponse.json(
+        { error: "El correo electrónico ya está registrado." },
+        { status: 409 }
+      );
+    }
+
+    const user = await createUser(nombre, correo, password, zonaHoraria);
+
+    return NextResponse.json(
+      {
+        id: user.id,
+        nombre: user.nombre,
+        correo: user.correo,
+        zonaHoraria: user.zona_horaria ?? null,
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    console.error("[POST /api/usuarios]", error);
+
+    if (
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      (error as { code?: string }).code === "SQLITE_CONSTRAINT"
+    ) {
+      return NextResponse.json(
+        { error: "El correo electrónico ya está registrado." },
+        { status: 409 }
+      );
+    }
+
+    return NextResponse.json(
+      { error: "No se pudo crear el usuario" },
       { status: 500 }
     );
   }

--- a/frontend/lib/db.ts
+++ b/frontend/lib/db.ts
@@ -187,7 +187,8 @@ export async function getUserByEmail(
 export async function createUser(
   nombre: string,
   correo: string,
-  password: string
+  password: string,
+  zonaHoraria?: string | null
 ): Promise<PublicUser> {
   if (!nombre || !correo || !password) {
     throw new Error("Nombre, correo y contraseña son requeridos");
@@ -196,8 +197,8 @@ export async function createUser(
   const passwordHash = await bcrypt.hash(password, 10);
 
   const insertResult = await runQuery(
-    "INSERT INTO usuarios (nombre, correo, password_hash, zona_horaria, creado_en) VALUES (?, ?, ?, NULL, datetime('now'))",
-    [nombre, correo, passwordHash]
+    "INSERT INTO usuarios (nombre, correo, password_hash, zona_horaria, creado_en) VALUES (?, ?, ?, ?, datetime('now'))",
+    [nombre, correo, passwordHash, zonaHoraria ?? null]
   );
 
   const insertedId = Number(insertResult.lastID);


### PR DESCRIPTION
## Summary
- fix invitation acceptance/rejection handlers to use the new params context and validate invitation state
- allow creating users through the /api/usuarios endpoint with proper validation and hashed passwords
- extend createUser helper to accept an optional time zone when inserting users

## Testing
- npm run lint *(fails: Invalid project directory provided, no such directory: /workspace/agenda-inteligente/frontend/lint)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912d52e21908327a126acd28e301502)