### PR TITLE
Fix invitation handlers for Next.js 16 params

### DIFF
--- a/frontend/app/api/invitaciones/[id]/aceptar/route.ts
+++ b/frontend/app/api/invitaciones/[id]/aceptar/route.ts
@@ -10,7 +10,7 @@ interface InvitacionRow {
 
 export async function POST(
   _: Request,
-  context: { params: { id: string } }
+  context: { params: Promise<{ id: string }> }
 ) {
   try {
     const user = await getUserFromSession();
@@ -18,7 +18,8 @@ export async function POST(
       return NextResponse.json({ error: "No autenticado" }, { status: 401 });
     }
 
-    const invitacionId = Number(context.params.id);
+    const params = await context.params;
+    const invitacionId = Number(params.id);
     if (!Number.isInteger(invitacionId) || invitacionId <= 0) {
       return NextResponse.json({ error: "Invitación inválida" }, { status: 400 });
     }
@@ -65,7 +66,7 @@ export async function POST(
       );
     }
 
-    return NextResponse.json({ success: true });
+    return NextResponse.json({ success: true, message: "Invitación aceptada" });
   } catch (error) {
     console.error("[POST /api/invitaciones/:id/aceptar]", error);
     return NextResponse.json(

--- a/frontend/app/api/invitaciones/[id]/rechazar/route.ts
+++ b/frontend/app/api/invitaciones/[id]/rechazar/route.ts
@@ -10,7 +10,7 @@ interface InvitacionRow {
 
 export async function POST(
   _: Request,
-  context: { params: { id: string } }
+  context: { params: Promise<{ id: string }> }
 ) {
   try {
     const user = await getUserFromSession();
@@ -18,7 +18,8 @@ export async function POST(
       return NextResponse.json({ error: "No autenticado" }, { status: 401 });
     }
 
-    const invitacionId = Number(context.params.id);
+    const params = await context.params;
+    const invitacionId = Number(params.id);
     if (!Number.isInteger(invitacionId) || invitacionId <= 0) {
       return NextResponse.json({ error: "Invitación inválida" }, { status: 400 });
     }
@@ -65,7 +66,7 @@ export async function POST(
       );
     }
 
-    return NextResponse.json({ success: true });
+    return NextResponse.json({ success: true, message: "Invitación rechazada" });
   } catch (error) {
     console.error("[POST /api/invitaciones/:id/rechazar]", error);
     return NextResponse.json(


### PR DESCRIPTION
## Summary
- adapt the invitation accept/reject API handlers to await the promise-based params object in Next.js 16
- return descriptive success messages while keeping validation and state updates intact

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912dcaab90c832797298595a255b92b)