### PR TITLE
feat: support collaborative internal events

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -127,6 +127,7 @@ CREATE INDEX IF NOT EXISTS idx_participantes_reunion ON participantes_reunion(id
 CREATE TABLE IF NOT EXISTS eventos_internos (
     id              INTEGER PRIMARY KEY AUTOINCREMENT,
     id_usuario      INTEGER NOT NULL,
+    id_equipo       INTEGER,
     titulo          VARCHAR(255) NOT NULL,
     descripcion     TEXT,
     inicio          DATETIME NOT NULL,
@@ -135,5 +136,18 @@ CREATE TABLE IF NOT EXISTS eventos_internos (
     tipo            TEXT CHECK(tipo IN ('personal','equipo','otro')) DEFAULT 'personal',
     recordatorio    INTEGER DEFAULT 0,  -- minutos antes del evento
     creado_en       DATETIME DEFAULT CURRENT_TIMESTAMP,
-    FOREIGN KEY (id_usuario) REFERENCES usuarios(id) ON DELETE CASCADE
+    FOREIGN KEY (id_usuario) REFERENCES usuarios(id) ON DELETE CASCADE,
+    FOREIGN KEY (id_equipo) REFERENCES equipos(id) ON DELETE SET NULL
+);
+
+CREATE TABLE IF NOT EXISTS participantes_evento_interno (
+    id                INTEGER PRIMARY KEY AUTOINCREMENT,
+    id_evento         INTEGER NOT NULL,
+    id_usuario        INTEGER NOT NULL,
+    estado_asistencia TEXT CHECK(estado_asistencia IN ('pendiente','aceptado','rechazado')) DEFAULT 'pendiente',
+    invitado_en       DATETIME DEFAULT CURRENT_TIMESTAMP,
+    respondido_en     DATETIME,
+    FOREIGN KEY (id_evento) REFERENCES eventos_internos(id) ON DELETE CASCADE,
+    FOREIGN KEY (id_usuario) REFERENCES usuarios(id) ON DELETE CASCADE,
+    UNIQUE (id_evento, id_usuario)
 );

--- a/frontend/app/api/events/[id]/respuesta/route.ts
+++ b/frontend/app/api/events/[id]/respuesta/route.ts
@@ -1,0 +1,112 @@
+import { NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { getQuery, runQuery } from "@/lib/db";
+
+type EstadoAsistencia = "pendiente" | "aceptado" | "rechazado";
+
+async function obtenerUsuarioAutenticado(): Promise<number | null> {
+  const cookieStore = await cookies();
+  const cookie = cookieStore.get("user_id");
+
+  if (!cookie?.value) {
+    return null;
+  }
+
+  const userId = Number(cookie.value);
+  if (!Number.isFinite(userId)) {
+    return null;
+  }
+
+  return userId;
+}
+
+export async function PATCH(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) {
+  try {
+    const userId = await obtenerUsuarioAutenticado();
+    if (!userId) {
+      return NextResponse.json({ error: "No autenticado" }, { status: 401 });
+    }
+
+    const { id } = await context.params;
+    const eventId = Number(id);
+    if (!Number.isInteger(eventId)) {
+      return NextResponse.json(
+        { error: "Identificador de evento inválido" },
+        { status: 400 }
+      );
+    }
+
+    const evento = await getQuery<{ id: number; tipo: string }>(
+      `SELECT id, tipo
+       FROM eventos_internos
+       WHERE id = ?`,
+      [eventId]
+    );
+
+    if (!evento) {
+      return NextResponse.json(
+        { error: "Evento no encontrado" },
+        { status: 404 }
+      );
+    }
+
+    if (evento.tipo !== "equipo") {
+      return NextResponse.json(
+        { error: "Este evento no admite confirmación de asistencia" },
+        { status: 400 }
+      );
+    }
+
+    const participante = await getQuery<{ id: number }>(
+      `SELECT id
+       FROM participantes_evento_interno
+       WHERE id_evento = ? AND id_usuario = ?`,
+      [eventId, userId]
+    );
+
+    if (!participante) {
+      return NextResponse.json(
+        { error: "No estás invitado a este evento" },
+        { status: 403 }
+      );
+    }
+
+    const body = await request.json();
+    const { estado } = body ?? {};
+
+    const estadosValidos: EstadoAsistencia[] = [
+      "pendiente",
+      "aceptado",
+      "rechazado",
+    ];
+
+    if (!estadosValidos.includes(estado)) {
+      return NextResponse.json(
+        { error: "Estado de asistencia inválido" },
+        { status: 400 }
+      );
+    }
+
+    const respondidoEn =
+      estado === "pendiente" ? null : new Date().toISOString();
+
+    await runQuery(
+      `UPDATE participantes_evento_interno
+       SET estado_asistencia = ?, respondido_en = ?
+       WHERE id_evento = ? AND id_usuario = ?`,
+      [estado, respondidoEn, eventId, userId]
+    );
+
+    return NextResponse.json({ message: "Asistencia actualizada" });
+  } catch (error) {
+    console.error("[PATCH /api/events/:id/respuesta]", error);
+    return NextResponse.json(
+      { error: "Error interno del servidor" },
+      { status: 500 }
+    );
+  }
+}
+

--- a/frontend/app/api/events/[id]/route.ts
+++ b/frontend/app/api/events/[id]/route.ts
@@ -5,6 +5,7 @@ import { getQuery, runQuery } from "@/lib/db";
 interface EventoInternoRow {
   id: number;
   id_usuario: number;
+  id_equipo: number | null;
   titulo: string;
   descripcion: string | null;
   inicio: string;
@@ -32,7 +33,8 @@ async function obtenerEventoDelUsuario(
   userId: number
 ): Promise<EventoInternoRow | null> {
   const evento = await getQuery<EventoInternoRow>(
-    "SELECT id, id_usuario, titulo, descripcion, inicio, fin, ubicacion, tipo, recordatorio, creado_en FROM eventos_internos WHERE id = ? AND id_usuario = ?",
+    `SELECT id, id_usuario, id_equipo, titulo, descripcion, inicio, fin, ubicacion, tipo, recordatorio, creado_en
+     FROM eventos_internos WHERE id = ? AND id_usuario = ?`,
     [id, userId]
   );
 

--- a/frontend/lib/db.ts
+++ b/frontend/lib/db.ts
@@ -70,6 +70,34 @@ function initializeTeamSchema(database: SqliteDatabase) {
         }
       }
     );
+
+    database.run(
+      "ALTER TABLE eventos_internos ADD COLUMN id_equipo INTEGER REFERENCES equipos(id) ON DELETE SET NULL",
+      (error) => {
+        if (error && !String(error.message).includes("duplicate column name")) {
+          console.error("[DB] Error agregando columna id_equipo en eventos_internos", error);
+        }
+      }
+    );
+
+    database.run(
+      `CREATE TABLE IF NOT EXISTS participantes_evento_interno (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        id_evento INTEGER NOT NULL,
+        id_usuario INTEGER NOT NULL,
+        estado_asistencia TEXT CHECK(estado_asistencia IN ('pendiente','aceptado','rechazado')) DEFAULT 'pendiente',
+        invitado_en DATETIME DEFAULT CURRENT_TIMESTAMP,
+        respondido_en DATETIME,
+        FOREIGN KEY (id_evento) REFERENCES eventos_internos(id) ON DELETE CASCADE,
+        FOREIGN KEY (id_usuario) REFERENCES usuarios(id) ON DELETE CASCADE,
+        UNIQUE (id_evento, id_usuario)
+      )`,
+      (error) => {
+        if (error) {
+          console.error("[DB] Error creando la tabla participantes_evento_interno", error);
+        }
+      }
+    );
   });
 }
 


### PR DESCRIPTION
## Summary
- add an optional team relationship to internal events and create the participants table for invitations
- extend the events API to manage team invites and expose attendance plus add a response endpoint for invitees
- update the events dashboard UI to support team selection, show attendance status, and allow responding to invites

## Testing
- npm run lint *(fails: Next.js lint expects a non-existent /frontend/lint directory in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913a15990308327a50a453621629ab4)