### PR TITLE
Add empty Turbopack config to Next.js configuration

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -3,6 +3,9 @@ const path = require("path");
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  // 👇 Nueva configuración requerida por Next.js 16 para silenciar el error cuando coexisten ajustes de Webpack.
+  turbopack: {},
+  // Si necesitas seguir usando Webpack (por ejemplo, por alias personalizados), ejecuta `next dev --webpack`.
   webpack: (config) => {
     config.resolve = config.resolve || {};
     config.resolve.alias = config.resolve.alias || {};


### PR DESCRIPTION
## Summary
- add an empty Turbopack configuration so Next.js 16 stops erroring when the webpack hook is defined
- document how to keep using webpack explicitly while preserving the custom alias configuration

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691420f66ecc8327a02af26330010311)