### PR TITLE
feat: transform inicio into a daily dashboard

### DIFF
--- a/frontend/app/api/dashboard/today/route.ts
+++ b/frontend/app/api/dashboard/today/route.ts
@@ -1,0 +1,357 @@
+import { NextResponse } from "next/server";
+import { getUserFromSession } from "@/lib/auth";
+import { allQuery, getQuery } from "@/lib/db";
+
+type TipoTareaNormalizada = "tarea" | "tarea_grupal";
+
+type TareaDinamicaRow = {
+  id: number;
+  titulo: string;
+  descripcion?: string | null;
+  fecha?: string | null;
+  id_equipo?: number | null;
+  es_grupal?: number | boolean | null;
+  tipo_registro?: string | null;
+  completada?: number | boolean | null;
+  equipo_nombre?: string | null;
+};
+
+type EventoInternoRow = {
+  id: number;
+  titulo: string;
+  descripcion: string | null;
+  inicio: string;
+  fin: string;
+  ubicacion: string | null;
+  tipo: "personal" | "equipo" | "otro";
+  equipo_nombre: string | null;
+};
+
+type DashboardEvento = {
+  id: number;
+  titulo: string;
+  descripcion: string | null;
+  inicio: string;
+  fin: string;
+  tipo: "personal" | "equipo" | "otro";
+  equipoNombre: string | null;
+};
+
+type DashboardTarea = {
+  id: number;
+  titulo: string;
+  descripcion: string | null;
+  fecha: string | null;
+  tipo: TipoTareaNormalizada;
+  equipoNombre: string | null;
+  completada: boolean;
+};
+
+type DashboardTodayResponse = {
+  nombre: string;
+  fechaIso: string;
+  fechaLegible: string;
+  totalEventos: number;
+  totalTareas: number;
+  eventos: DashboardEvento[];
+  tareas: DashboardTarea[];
+};
+
+interface PragmaTableInfoRow {
+  name: string;
+}
+
+function inferirTipoTarea(tarea: TareaDinamicaRow): TipoTareaNormalizada {
+  const { es_grupal, tipo_registro, id_equipo } = tarea;
+
+  if (typeof es_grupal === "number") {
+    return es_grupal !== 0 ? "tarea_grupal" : "tarea";
+  }
+
+  if (typeof es_grupal === "boolean") {
+    return es_grupal ? "tarea_grupal" : "tarea";
+  }
+
+  if (typeof tipo_registro === "string") {
+    const valorNormalizado = tipo_registro.trim().toLowerCase();
+    if (["grupal", "equipo", "team", "colaborativa", "grupo"].includes(valorNormalizado)) {
+      return "tarea_grupal";
+    }
+  }
+
+  if (typeof id_equipo === "number" && Number.isFinite(id_equipo)) {
+    return "tarea_grupal";
+  }
+
+  return "tarea";
+}
+
+function normalizarBandera(valor: unknown): boolean {
+  if (typeof valor === "boolean") {
+    return valor;
+  }
+
+  if (typeof valor === "number") {
+    return valor !== 0;
+  }
+
+  if (typeof valor === "string") {
+    const limpio = valor.trim().toLowerCase();
+    if (["1", "true", "si", "sí"].includes(limpio)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function obtenerFechaIso(fecha: string | null | undefined): string | null {
+  if (!fecha) {
+    return null;
+  }
+
+  const trimmed = fecha.trim();
+
+  if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+    return trimmed;
+  }
+
+  if (/^\d{4}-\d{2}-\d{2}T/.test(trimmed)) {
+    return trimmed.slice(0, 10);
+  }
+
+  const parsed = new Date(trimmed);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+
+  const year = parsed.getFullYear();
+  const month = String(parsed.getMonth() + 1).padStart(2, "0");
+  const day = String(parsed.getDate()).padStart(2, "0");
+
+  return `${year}-${month}-${day}`;
+}
+
+async function obtenerTareasParaHoy(userId: number, hoyIso: string): Promise<DashboardTarea[]> {
+  try {
+    const tablaTareas = await getQuery<{ name: string }>(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'tareas'"
+    );
+
+    if (!tablaTareas) {
+      return [];
+    }
+
+    const columnas = await allQuery<PragmaTableInfoRow>("PRAGMA table_info('tareas')");
+    const nombresColumnas = new Set(columnas.map((columna) => columna.name));
+
+    if (!nombresColumnas.has("id") || !nombresColumnas.has("titulo")) {
+      return [];
+    }
+
+    const fechaColumna = nombresColumnas.has("fecha")
+      ? "fecha"
+      : nombresColumnas.has("fecha_limite")
+        ? "fecha_limite"
+        : nombresColumnas.has("vencimiento")
+          ? "vencimiento"
+          : null;
+
+    if (!fechaColumna) {
+      return [];
+    }
+
+    const campos: string[] = [
+      "t.id AS id",
+      "t.titulo AS titulo",
+      `t.${fechaColumna} AS fecha`,
+    ];
+
+    if (nombresColumnas.has("descripcion")) {
+      campos.push("t.descripcion AS descripcion");
+    }
+
+    if (nombresColumnas.has("id_equipo")) {
+      campos.push("t.id_equipo AS id_equipo");
+    }
+
+    if (nombresColumnas.has("es_grupal")) {
+      campos.push("t.es_grupal AS es_grupal");
+    }
+
+    if (nombresColumnas.has("tipo")) {
+      campos.push("t.tipo AS tipo_registro");
+    }
+
+    if (nombresColumnas.has("completada")) {
+      campos.push("t.completada AS completada");
+    }
+
+    let joins = "";
+    let membershipJoin = "";
+
+    if (nombresColumnas.has("id_equipo")) {
+      joins += " LEFT JOIN equipos eq ON eq.id = t.id_equipo";
+      campos.push("eq.nombre AS equipo_nombre");
+
+      membershipJoin =
+        " LEFT JOIN miembros_equipo me ON me.id_equipo = t.id_equipo AND me.id_usuario = ? AND me.estado = 'aceptado'";
+      joins += membershipJoin;
+    }
+
+    const condiciones: string[] = [];
+    const filtrosAnd: string[] = [];
+    const parametros: unknown[] = [];
+
+    if (membershipJoin) {
+      parametros.push(userId);
+    }
+
+    if (nombresColumnas.has("id_usuario")) {
+      if (membershipJoin) {
+        condiciones.push("(t.id_usuario = ? OR me.id IS NOT NULL)");
+      } else {
+        condiciones.push("t.id_usuario = ?");
+      }
+      parametros.push(userId);
+    } else if (membershipJoin) {
+      condiciones.push("me.id IS NOT NULL");
+    }
+
+    if (nombresColumnas.has("completada")) {
+      filtrosAnd.push("(t.completada IS NULL OR t.completada = 0)");
+    }
+
+    const condicionesTotales: string[] = [];
+    if (condiciones.length > 0) {
+      if (condiciones.length === 1) {
+        condicionesTotales.push(condiciones[0]);
+      } else {
+        condicionesTotales.push(`(${condiciones.join(" OR ")})`);
+      }
+    }
+
+    if (filtrosAnd.length > 0) {
+      condicionesTotales.push(filtrosAnd.join(" AND "));
+    }
+
+    const whereClause = condicionesTotales.length > 0 ? ` WHERE ${condicionesTotales.join(" AND ")}` : "";
+
+    const query = `SELECT ${campos.join(", ")} FROM tareas t${joins}${whereClause}`;
+    const tareas = await allQuery<TareaDinamicaRow>(query, parametros);
+
+    return tareas
+      .filter((tarea) => {
+        const fechaIso = obtenerFechaIso(tarea.fecha ?? null);
+        return fechaIso === hoyIso;
+      })
+      .map((tarea) => {
+        const tipo = inferirTipoTarea(tarea);
+        const completada = normalizarBandera(tarea.completada);
+
+        return {
+          id: tarea.id,
+          titulo: tarea.titulo,
+          descripcion: tarea.descripcion ?? null,
+          fecha: tarea.fecha ?? null,
+          tipo,
+          equipoNombre: tarea.equipo_nombre ?? null,
+          completada,
+        } satisfies DashboardTarea;
+      });
+  } catch (error) {
+    console.warn("[GET /api/dashboard/today] No se pudieron obtener las tareas", error);
+    return [];
+  }
+}
+
+async function obtenerEventosParaHoy(userId: number, hoyIso: string): Promise<DashboardEvento[]> {
+  const eventos = await allQuery<EventoInternoRow>(
+    `SELECT
+      e.id,
+      e.titulo,
+      e.descripcion,
+      e.inicio,
+      e.fin,
+      e.ubicacion,
+      e.tipo,
+      eq.nombre AS equipo_nombre
+    FROM eventos_internos e
+    LEFT JOIN participantes_evento_interno pei
+      ON pei.id_evento = e.id AND pei.id_usuario = ?
+    LEFT JOIN equipos eq ON eq.id = e.id_equipo
+    WHERE e.id_usuario = ? OR pei.id IS NOT NULL`,
+    [userId, userId]
+  );
+
+  return eventos.filter((evento) => {
+    const inicioIso = obtenerFechaIso(evento.inicio);
+    const finIso = obtenerFechaIso(evento.fin);
+
+    if (inicioIso && finIso) {
+      return inicioIso <= hoyIso && finIso >= hoyIso;
+    }
+
+    if (inicioIso) {
+      return inicioIso === hoyIso;
+    }
+
+    if (finIso) {
+      return finIso === hoyIso;
+    }
+
+    return false;
+  }).map((evento) => ({
+    id: evento.id,
+    titulo: evento.titulo,
+    descripcion: evento.descripcion,
+    inicio: evento.inicio,
+    fin: evento.fin,
+    tipo: evento.tipo,
+    equipoNombre: evento.equipo_nombre,
+  }));
+}
+
+export async function GET() {
+  try {
+    const user = await getUserFromSession();
+    if (!user) {
+      return NextResponse.json({ error: "No autenticado" }, { status: 401 });
+    }
+
+    const ahora = new Date();
+    const hoyIso = `${ahora.getFullYear()}-${String(ahora.getMonth() + 1).padStart(2, "0")}-${String(ahora.getDate()).padStart(2, "0")}`;
+
+    const formatoLegible = new Intl.DateTimeFormat("es-ES", {
+      weekday: "long",
+      day: "numeric",
+      month: "long",
+      year: "numeric",
+    }).format(ahora);
+
+    const [eventos, tareas] = await Promise.all([
+      obtenerEventosParaHoy(user.id, hoyIso),
+      obtenerTareasParaHoy(user.id, hoyIso),
+    ]);
+
+    const tareasPendientes = tareas.filter((tarea) => !tarea.completada);
+
+    const payload: DashboardTodayResponse = {
+      nombre: user.nombre,
+      fechaIso: hoyIso,
+      fechaLegible: formatoLegible,
+      totalEventos: eventos.length,
+      totalTareas: tareasPendientes.length,
+      eventos,
+      tareas: tareasPendientes,
+    };
+
+    return NextResponse.json(payload);
+  } catch (error) {
+    console.error("[GET /api/dashboard/today]", error);
+    return NextResponse.json(
+      { error: "Error interno del servidor" },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/app/api/invitaciones/[id]/aceptar/route.ts
+++ b/frontend/app/api/invitaciones/[id]/aceptar/route.ts
@@ -8,9 +8,9 @@ interface InvitacionRow {
   estado: string;
 }
 
-export async function POST(
-  _: Request,
-  context: { params: Promise<{ id: string }> }
+async function responderInvitacion(
+  context: { params: Promise<{ id: string }> },
+  nuevoEstado: "aceptado"
 ) {
   try {
     const user = await getUserFromSession();
@@ -54,9 +54,9 @@ export async function POST(
 
     const update = await db.run(
       `UPDATE miembros_equipo
-       SET estado = 'aceptado', respondido_en = CURRENT_TIMESTAMP
+       SET estado = ?, respondido_en = CURRENT_TIMESTAMP
        WHERE id = ?`,
-      [invitacionId]
+      [nuevoEstado, invitacionId]
     );
 
     if (!update.changes) {
@@ -68,10 +68,24 @@ export async function POST(
 
     return NextResponse.json({ success: true, message: "Invitación aceptada" });
   } catch (error) {
-    console.error("[POST /api/invitaciones/:id/aceptar]", error);
+    console.error("[/api/invitaciones/:id/aceptar]", error);
     return NextResponse.json(
       { error: "No se pudo aceptar la invitación" },
       { status: 500 }
     );
   }
+}
+
+export async function POST(
+  _request: Request,
+  context: { params: Promise<{ id: string }> }
+) {
+  return responderInvitacion(context, "aceptado");
+}
+
+export async function PATCH(
+  _request: Request,
+  context: { params: Promise<{ id: string }> }
+) {
+  return responderInvitacion(context, "aceptado");
 }

--- a/frontend/app/api/invitaciones/[id]/rechazar/route.ts
+++ b/frontend/app/api/invitaciones/[id]/rechazar/route.ts
@@ -8,9 +8,9 @@ interface InvitacionRow {
   estado: string;
 }
 
-export async function POST(
-  _: Request,
-  context: { params: Promise<{ id: string }> }
+async function responderInvitacion(
+  context: { params: Promise<{ id: string }> },
+  nuevoEstado: "rechazado"
 ) {
   try {
     const user = await getUserFromSession();
@@ -54,9 +54,9 @@ export async function POST(
 
     const update = await db.run(
       `UPDATE miembros_equipo
-       SET estado = 'rechazado', respondido_en = CURRENT_TIMESTAMP
+       SET estado = ?, respondido_en = CURRENT_TIMESTAMP
        WHERE id = ?`,
-      [invitacionId]
+      [nuevoEstado, invitacionId]
     );
 
     if (!update.changes) {
@@ -68,10 +68,24 @@ export async function POST(
 
     return NextResponse.json({ success: true, message: "Invitación rechazada" });
   } catch (error) {
-    console.error("[POST /api/invitaciones/:id/rechazar]", error);
+    console.error("[/api/invitaciones/:id/rechazar]", error);
     return NextResponse.json(
       { error: "No se pudo rechazar la invitación" },
       { status: 500 }
     );
   }
+}
+
+export async function POST(
+  _request: Request,
+  context: { params: Promise<{ id: string }> }
+) {
+  return responderInvitacion(context, "rechazado");
+}
+
+export async function PATCH(
+  _request: Request,
+  context: { params: Promise<{ id: string }> }
+) {
+  return responderInvitacion(context, "rechazado");
 }

--- a/frontend/app/api/notificaciones/route.ts
+++ b/frontend/app/api/notificaciones/route.ts
@@ -1,0 +1,189 @@
+import { NextResponse } from "next/server";
+import { getUserFromSession } from "@/lib/auth";
+import { allQuery } from "@/lib/db";
+
+type EstadoInvitacion = "pendiente" | "aceptado" | "rechazado";
+
+type Notificacion = {
+  id: string;
+  mensaje: string;
+  fecha: string;
+  tipo: "equipo" | "evento";
+  estado: EstadoInvitacion | null;
+  puedeResponder: boolean;
+  invitacionId?: number;
+};
+
+type InvitacionEquipoPendienteRow = {
+  id: number;
+  invitado_en: string;
+  equipo_nombre: string;
+  invitador_nombre: string | null;
+};
+
+type RespuestaEquipoRow = {
+  id: number;
+  respondido_en: string | null;
+  equipo_nombre: string;
+  miembro_nombre: string;
+  estado: EstadoInvitacion;
+};
+
+type InvitacionEventoPendienteRow = {
+  id: number;
+  invitado_en: string;
+  titulo_evento: string;
+  organizador_nombre: string | null;
+};
+
+type RespuestaEventoRow = {
+  id: number;
+  respondido_en: string | null;
+  titulo_evento: string;
+  participante_nombre: string;
+  estado_asistencia: EstadoInvitacion;
+};
+
+function normalizarFecha(fecha: string | null): string {
+  if (!fecha) {
+    return new Date().toISOString();
+  }
+
+  const parsed = new Date(fecha);
+  if (Number.isNaN(parsed.getTime())) {
+    return new Date().toISOString();
+  }
+
+  return parsed.toISOString();
+}
+
+export async function GET() {
+  try {
+    const user = await getUserFromSession();
+    if (!user) {
+      return NextResponse.json({ error: "No autenticado" }, { status: 401 });
+    }
+
+    const [invitacionesEquipo, respuestasEquipo, invitacionesEvento, respuestasEvento] = await Promise.all([
+      allQuery<InvitacionEquipoPendienteRow>(
+        `SELECT
+          me.id,
+          me.invitado_en,
+          e.nombre AS equipo_nombre,
+          invitador.nombre AS invitador_nombre
+        FROM miembros_equipo me
+        INNER JOIN equipos e ON e.id = me.id_equipo
+        LEFT JOIN usuarios invitador ON invitador.id = me.invitado_por
+        WHERE me.id_usuario = ? AND me.estado = 'pendiente'`,
+        [user.id]
+      ),
+      allQuery<RespuestaEquipoRow>(
+        `SELECT
+          me.id,
+          me.respondido_en,
+          e.nombre AS equipo_nombre,
+          miembro.nombre AS miembro_nombre,
+          me.estado AS estado
+        FROM miembros_equipo me
+        INNER JOIN equipos e ON e.id = me.id_equipo
+        INNER JOIN usuarios miembro ON miembro.id = me.id_usuario
+        WHERE me.invitado_por = ? AND me.estado IN ('aceptado','rechazado')`,
+        [user.id]
+      ),
+      allQuery<InvitacionEventoPendienteRow>(
+        `SELECT
+          pei.id,
+          pei.invitado_en,
+          e.titulo AS titulo_evento,
+          organizador.nombre AS organizador_nombre
+        FROM participantes_evento_interno pei
+        INNER JOIN eventos_internos e ON e.id = pei.id_evento
+        LEFT JOIN usuarios organizador ON organizador.id = e.id_usuario
+        WHERE pei.id_usuario = ? AND pei.estado_asistencia = 'pendiente'`,
+        [user.id]
+      ),
+      allQuery<RespuestaEventoRow>(
+        `SELECT
+          pei.id,
+          pei.respondido_en,
+          e.titulo AS titulo_evento,
+          participante.nombre AS participante_nombre,
+          pei.estado_asistencia
+        FROM participantes_evento_interno pei
+        INNER JOIN eventos_internos e ON e.id = pei.id_evento
+        INNER JOIN usuarios participante ON participante.id = pei.id_usuario
+        WHERE e.id_usuario = ? AND pei.estado_asistencia IN ('aceptado','rechazado')`,
+        [user.id]
+      ),
+    ]);
+
+    const notificaciones: Notificacion[] = [];
+
+    invitacionesEquipo.forEach((invitacion) => {
+      const fecha = normalizarFecha(invitacion.invitado_en);
+      const invitador = invitacion.invitador_nombre ?? "Alguien";
+      notificaciones.push({
+        id: `equipo-pendiente-${invitacion.id}`,
+        mensaje: `${invitador} te invitó al equipo ${invitacion.equipo_nombre}`,
+        fecha,
+        tipo: "equipo",
+        estado: "pendiente",
+        puedeResponder: true,
+        invitacionId: invitacion.id,
+      });
+    });
+
+    respuestasEquipo.forEach((respuesta) => {
+      const fecha = normalizarFecha(respuesta.respondido_en);
+      const accion = respuesta.estado === "aceptado" ? "aceptó" : "rechazó";
+      notificaciones.push({
+        id: `equipo-respuesta-${respuesta.id}`,
+        mensaje: `${respuesta.miembro_nombre} ${accion} tu invitación al equipo ${respuesta.equipo_nombre}`,
+        fecha,
+        tipo: "equipo",
+        estado: respuesta.estado,
+        puedeResponder: false,
+      });
+    });
+
+    invitacionesEvento.forEach((invitacion) => {
+      const fecha = normalizarFecha(invitacion.invitado_en);
+      const organizador = invitacion.organizador_nombre ?? "Alguien";
+      notificaciones.push({
+        id: `evento-pendiente-${invitacion.id}`,
+        mensaje: `${organizador} te invitó al evento ${invitacion.titulo_evento}`,
+        fecha,
+        tipo: "evento",
+        estado: "pendiente",
+        puedeResponder: false,
+      });
+    });
+
+    respuestasEvento.forEach((respuesta) => {
+      const fecha = normalizarFecha(respuesta.respondido_en);
+      const accion = respuesta.estado_asistencia === "aceptado" ? "aceptó" : "rechazó";
+      notificaciones.push({
+        id: `evento-respuesta-${respuesta.id}`,
+        mensaje: `${respuesta.participante_nombre} ${accion} tu invitación al evento ${respuesta.titulo_evento}`,
+        fecha,
+        tipo: "evento",
+        estado: respuesta.estado_asistencia,
+        puedeResponder: false,
+      });
+    });
+
+    const ordenadas = notificaciones.sort((a, b) => {
+      const fechaA = new Date(a.fecha).getTime();
+      const fechaB = new Date(b.fecha).getTime();
+      return fechaB - fechaA;
+    });
+
+    return NextResponse.json({ notificaciones: ordenadas.slice(0, 10) });
+  } catch (error) {
+    console.error("[GET /api/notificaciones]", error);
+    return NextResponse.json(
+      { error: "Error al obtener las notificaciones" },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a dashboard API that consolidates today's events and tasks for the signed-in user
- expose a notifications feed with support for responding to team invitations via PATCH endpoints
- redesign the /inicio panel to surface the daily summary, today's items, a read-only calendar, and recent activity

## Testing
- npm run lint *(fails: "Invalid project directory provided, no such directory: .../frontend/lint")*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691424c2c8888327a6cb8c0b5f3d8357)