### PR TITLE
Fix JSX fragment closure on eventos page

### DIFF
--- a/frontend/app/(panel)/eventos/page.tsx
+++ b/frontend/app/(panel)/eventos/page.tsx
@@ -447,6 +447,7 @@ const CalendarioUnificadoPage = () => {
           </button>
         </div>
       )}
+      </div>
     </>
   );
 };


### PR DESCRIPTION
## Summary
- close the eventos page JSX structure by restoring the missing closing div and fragment

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691516c940788327bea5a451013d9d65)