### PR TITLE
Fix dashboard pending invitations handling

### DIFF
--- a/frontend/app/api/events/[id]/respuesta/route.ts
+++ b/frontend/app/api/events/[id]/respuesta/route.ts
@@ -4,6 +4,8 @@ import { getQuery, runQuery } from "@/lib/db";
 
 type EstadoAsistencia = "pendiente" | "aceptado" | "rechazado";
 
+const ESTADOS_VALIDOS = new Set<EstadoAsistencia>(["pendiente", "aceptado", "rechazado"]);
+
 async function obtenerUsuarioAutenticado(): Promise<number | null> {
   const cookieStore = await cookies();
   const cookie = cookieStore.get("user_id");
@@ -20,9 +22,61 @@ async function obtenerUsuarioAutenticado(): Promise<number | null> {
   return userId;
 }
 
+async function actualizarEstadoAsistencia(
+  eventId: number,
+  userId: number,
+  estado: EstadoAsistencia,
+) {
+  const evento = await getQuery<{ id: number; tipo: string }>(
+    `SELECT id, tipo
+     FROM eventos_internos
+     WHERE id = ?`,
+    [eventId],
+  );
+
+  if (!evento) {
+    return NextResponse.json(
+      { error: "Evento no encontrado" },
+      { status: 404 },
+    );
+  }
+
+  if (evento.tipo !== "equipo") {
+    return NextResponse.json(
+      { error: "Este evento no admite confirmación de asistencia" },
+      { status: 400 },
+    );
+  }
+
+  const participante = await getQuery<{ id: number }>(
+    `SELECT id
+     FROM participantes_evento_interno
+     WHERE id_evento = ? AND id_usuario = ?`,
+    [eventId, userId],
+  );
+
+  if (!participante) {
+    return NextResponse.json(
+      { error: "No estás invitado a este evento" },
+      { status: 403 },
+    );
+  }
+
+  const respondidoEn = estado === "pendiente" ? null : new Date().toISOString();
+
+  await runQuery(
+    `UPDATE participantes_evento_interno
+     SET estado_asistencia = ?, respondido_en = ?
+     WHERE id_evento = ? AND id_usuario = ?`,
+    [estado, respondidoEn, eventId, userId],
+  );
+
+  return NextResponse.json({ message: "Asistencia actualizada", estado });
+}
+
 export async function PATCH(
   request: NextRequest,
-  context: { params: Promise<{ id: string }> }
+  context: { params: Promise<{ id: string }> },
 ) {
   try {
     const userId = await obtenerUsuarioAutenticado();
@@ -35,78 +89,67 @@ export async function PATCH(
     if (!Number.isInteger(eventId)) {
       return NextResponse.json(
         { error: "Identificador de evento inválido" },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
-    const evento = await getQuery<{ id: number; tipo: string }>(
-      `SELECT id, tipo
-       FROM eventos_internos
-       WHERE id = ?`,
-      [eventId]
-    );
+    const body = await request.json().catch(() => null);
+    const estado = body?.estado as EstadoAsistencia | undefined;
 
-    if (!evento) {
-      return NextResponse.json(
-        { error: "Evento no encontrado" },
-        { status: 404 }
-      );
-    }
-
-    if (evento.tipo !== "equipo") {
-      return NextResponse.json(
-        { error: "Este evento no admite confirmación de asistencia" },
-        { status: 400 }
-      );
-    }
-
-    const participante = await getQuery<{ id: number }>(
-      `SELECT id
-       FROM participantes_evento_interno
-       WHERE id_evento = ? AND id_usuario = ?`,
-      [eventId, userId]
-    );
-
-    if (!participante) {
-      return NextResponse.json(
-        { error: "No estás invitado a este evento" },
-        { status: 403 }
-      );
-    }
-
-    const body = await request.json();
-    const { estado } = body ?? {};
-
-    const estadosValidos: EstadoAsistencia[] = [
-      "pendiente",
-      "aceptado",
-      "rechazado",
-    ];
-
-    if (!estadosValidos.includes(estado)) {
+    if (!estado || !ESTADOS_VALIDOS.has(estado)) {
       return NextResponse.json(
         { error: "Estado de asistencia inválido" },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
-    const respondidoEn =
-      estado === "pendiente" ? null : new Date().toISOString();
-
-    await runQuery(
-      `UPDATE participantes_evento_interno
-       SET estado_asistencia = ?, respondido_en = ?
-       WHERE id_evento = ? AND id_usuario = ?`,
-      [estado, respondidoEn, eventId, userId]
-    );
-
-    return NextResponse.json({ message: "Asistencia actualizada" });
+    return actualizarEstadoAsistencia(eventId, userId, estado);
   } catch (error) {
     console.error("[PATCH /api/events/:id/respuesta]", error);
     return NextResponse.json(
       { error: "Error interno del servidor" },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }
 
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
+  try {
+    const userId = await obtenerUsuarioAutenticado();
+    if (!userId) {
+      return NextResponse.json({ error: "No autenticado" }, { status: 401 });
+    }
+
+    const { id } = await context.params;
+    const eventId = Number(id);
+    if (!Number.isInteger(eventId)) {
+      return NextResponse.json(
+        { error: "Identificador de evento inválido" },
+        { status: 400 },
+      );
+    }
+
+    const estadoParam = request.nextUrl.searchParams.get("estado");
+    const estado = estadoParam && ESTADOS_VALIDOS.has(estadoParam as EstadoAsistencia)
+      ? (estadoParam as EstadoAsistencia)
+      : null;
+
+    if (!estado) {
+      return NextResponse.json(
+        { error: "Estado de asistencia inválido" },
+        { status: 400 },
+      );
+    }
+
+    return actualizarEstadoAsistencia(eventId, userId, estado);
+  } catch (error) {
+    console.error("[POST /api/events/:id/respuesta]", error);
+    return NextResponse.json(
+      { error: "Error interno del servidor" },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- include pending team event invitations with metadata in the dashboard API response
- surface pending invitations in the dashboard UI, activity feed, and calendar with dedicated styling and actions
- expose event invitation responses through the notifications API and support POST responses for team events

## Testing
- npm run lint --prefix frontend *(fails: Invalid project directory provided, no such directory: /workspace/agenda-inteligente/frontend/lint)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69151eb674f483279bd24694adad2cd7)