### PR TITLE
Add team administration capabilities

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -116,6 +116,7 @@ CREATE TABLE IF NOT EXISTS participantes_reunion (
 CREATE INDEX IF NOT EXISTS idx_cuentas_usuario      ON cuentas_conectadas(id_usuario);
 CREATE INDEX IF NOT EXISTS idx_eventos_cuenta       ON eventos_externos(id_cuenta);
 CREATE INDEX IF NOT EXISTS idx_miembros_equipo      ON miembros_equipo(id_equipo);
+CREATE INDEX IF NOT EXISTS idx_miembros_equipo_usuario ON miembros_equipo(id_usuario);
 CREATE INDEX IF NOT EXISTS idx_reuniones_equipo     ON reuniones_propuestas(id_equipo);
 CREATE INDEX IF NOT EXISTS idx_participantes_reunion ON participantes_reunion(id_reunion);
 

--- a/frontend/app/(panel)/equipos/page.tsx
+++ b/frontend/app/(panel)/equipos/page.tsx
@@ -8,6 +8,7 @@ interface EquipoItem {
   creado_en: string;
   creador_nombre: string | null;
   miembros: number;
+  rol: "administrador" | "miembro";
 }
 
 interface InvitacionItem {
@@ -28,6 +29,26 @@ interface FeedbackState {
   message: string;
 }
 
+interface MiembroEquipoDetalle {
+  id: number;
+  id_usuario: number;
+  nombre: string;
+  correo: string;
+  rol: "administrador" | "miembro";
+  estado: "pendiente" | "aceptado" | "rechazado";
+  invitado_en: string;
+  respondido_en: string | null;
+}
+
+interface EquipoDetalle {
+  id: number;
+  nombre: string;
+  creado_en: string;
+  creado_por: number;
+  creador_nombre: string | null;
+  miembros: MiembroEquipoDetalle[];
+}
+
 export default function EquiposPage() {
   const [equipos, setEquipos] = useState<EquipoItem[]>([]);
   const [invitaciones, setInvitaciones] = useState<InvitacionItem[]>([]);
@@ -38,10 +59,21 @@ export default function EquiposPage() {
   const [cargando, setCargando] = useState(true);
   const [creando, setCreando] = useState(false);
   const [procesandoInvitacion, setProcesandoInvitacion] = useState<number | null>(null);
+  const [modalEdicionAbierta, setModalEdicionAbierta] = useState(false);
+  const [equipoSeleccionadoId, setEquipoSeleccionadoId] = useState<number | null>(null);
+  const [equipoEditando, setEquipoEditando] = useState<EquipoDetalle | null>(null);
+  const [cargandoDetalle, setCargandoDetalle] = useState(false);
+  const [nuevoNombreEquipo, setNuevoNombreEquipo] = useState("");
+  const [invitadoAAgregar, setInvitadoAAgregar] = useState<string>("");
+  const [accionEnProgreso, setAccionEnProgreso] = useState<string | null>(null);
 
   useEffect(() => {
-    cargarDatos();
+    void cargarDatos();
   }, []);
+
+  function estaProcesando(clave: string) {
+    return accionEnProgreso === clave;
+  }
 
   async function cargarDatos() {
     setCargando(true);
@@ -67,7 +99,34 @@ export default function EquiposPage() {
     if (!respuesta.ok) {
       throw new Error(datos.error ?? "No se pudieron cargar los equipos");
     }
-    setEquipos(datos.equipos ?? []);
+
+    const equiposCrudos = Array.isArray(datos.equipos) ? datos.equipos : [];
+    const equiposNormalizados: EquipoItem[] = equiposCrudos
+      .map((equipo: Record<string, unknown>) => {
+        const id = Number(equipo.id);
+        const miembros = Number(equipo.miembros);
+        if (!Number.isInteger(id) || id <= 0 || !Number.isInteger(miembros) || miembros < 0) {
+          return null;
+        }
+
+        const rol =
+          equipo.rol_usuario === "administrador" ? "administrador" : "miembro";
+
+        return {
+          id,
+          nombre: typeof equipo.nombre === "string" ? equipo.nombre : "Equipo sin nombre",
+          creado_en: typeof equipo.creado_en === "string" ? equipo.creado_en : "",
+          creador_nombre:
+            typeof equipo.creador_nombre === "string"
+              ? equipo.creador_nombre
+              : null,
+          miembros,
+          rol,
+        } satisfies EquipoItem;
+      })
+      .filter((equipo): equipo is EquipoItem => equipo !== null);
+
+    setEquipos(equiposNormalizados);
   }
 
   async function obtenerInvitaciones() {
@@ -197,6 +256,341 @@ export default function EquiposPage() {
     }
   }
 
+  function cerrarModalEdicion() {
+    setModalEdicionAbierta(false);
+    setEquipoSeleccionadoId(null);
+    setEquipoEditando(null);
+    setNuevoNombreEquipo("");
+    setInvitadoAAgregar("");
+    setAccionEnProgreso(null);
+    setCargandoDetalle(false);
+  }
+
+  async function cargarDetalleEquipo(equipoId: number) {
+    setCargandoDetalle(true);
+    try {
+      const respuesta = await fetch(`/api/equipos/${equipoId}`, { cache: "no-store" });
+      const datos = await respuesta.json();
+      if (!respuesta.ok) {
+        throw new Error(
+          datos.error ?? "No se pudo obtener la información del equipo"
+        );
+      }
+
+      const equipo = datos.equipo ?? {};
+      const miembrosCrudos: Array<Partial<MiembroEquipoDetalle>> = Array.isArray(
+        datos.miembros
+      )
+        ? datos.miembros
+        : [];
+
+      const miembros = miembrosCrudos
+        .map((miembro) => {
+          const id = Number(miembro.id);
+          const usuarioId = Number((miembro as { id_usuario?: unknown }).id_usuario);
+          if (!Number.isInteger(id) || id <= 0 || !Number.isInteger(usuarioId) || usuarioId <= 0) {
+            return null;
+          }
+
+          const rol = miembro.rol === "administrador" ? "administrador" : "miembro";
+          const estado =
+            miembro.estado === "aceptado"
+              ? "aceptado"
+              : miembro.estado === "pendiente"
+              ? "pendiente"
+              : "rechazado";
+
+          return {
+            id,
+            id_usuario: usuarioId,
+            nombre:
+              typeof miembro.nombre === "string"
+                ? miembro.nombre
+                : "Usuario sin nombre",
+            correo: typeof miembro.correo === "string" ? miembro.correo : "",
+            rol,
+            estado,
+            invitado_en:
+              typeof miembro.invitado_en === "string"
+                ? miembro.invitado_en
+                : new Date().toISOString(),
+            respondido_en:
+              typeof miembro.respondido_en === "string"
+                ? miembro.respondido_en
+                : null,
+          } satisfies MiembroEquipoDetalle;
+        })
+        .filter((miembro): miembro is MiembroEquipoDetalle => miembro !== null);
+
+      const detalle: EquipoDetalle = {
+        id: Number(equipo.id),
+        nombre: typeof equipo.nombre === "string" ? equipo.nombre : "Equipo sin nombre",
+        creado_en: typeof equipo.creado_en === "string" ? equipo.creado_en : "",
+        creado_por: Number(equipo.creado_por ?? 0),
+        creador_nombre:
+          typeof equipo.creador_nombre === "string"
+            ? equipo.creador_nombre
+            : null,
+        miembros,
+      };
+
+      if (!Number.isInteger(detalle.id) || detalle.id <= 0) {
+        throw new Error("La información del equipo es inválida");
+      }
+
+      setEquipoEditando(detalle);
+      setNuevoNombreEquipo(detalle.nombre);
+    } catch (error) {
+      console.error(error);
+      setFeedback({
+        type: "error",
+        message:
+          error instanceof Error
+            ? error.message
+            : "No se pudo cargar la información del equipo",
+      });
+      cerrarModalEdicion();
+    } finally {
+      setCargandoDetalle(false);
+    }
+  }
+
+  function abrirModalEdicion(equipoId: number) {
+    setModalEdicionAbierta(true);
+    setEquipoSeleccionadoId(equipoId);
+    setEquipoEditando(null);
+    setNuevoNombreEquipo("");
+    setInvitadoAAgregar("");
+    void cargarDetalleEquipo(equipoId);
+  }
+
+  async function manejarEdicionNombre(evento: FormEvent<HTMLFormElement>) {
+    evento.preventDefault();
+    if (!equipoEditando) {
+      return;
+    }
+
+    const nombreActualizado = nuevoNombreEquipo.trim();
+    if (!nombreActualizado) {
+      setFeedback({ type: "error", message: "El nombre del equipo es obligatorio" });
+      return;
+    }
+
+    if (nombreActualizado === equipoEditando.nombre) {
+      setFeedback({ type: "error", message: "El nombre ingresado es igual al actual" });
+      return;
+    }
+
+    setAccionEnProgreso(`renombrar-${equipoEditando.id}`);
+    setFeedback(null);
+    try {
+      const respuesta = await fetch(`/api/equipos/${equipoEditando.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ nombre: nombreActualizado }),
+      });
+
+      const datos = await respuesta.json();
+      if (!respuesta.ok) {
+        throw new Error(datos.error ?? "No se pudo actualizar el equipo");
+      }
+
+      setEquipoEditando((prev) =>
+        prev ? { ...prev, nombre: nombreActualizado } : prev
+      );
+      setEquipos((prev) =>
+        prev.map((equipo) =>
+          equipo.id === equipoEditando.id
+            ? { ...equipo, nombre: nombreActualizado }
+            : equipo
+        )
+      );
+      setFeedback({
+        type: "success",
+        message: datos.message ?? "Equipo actualizado correctamente",
+      });
+    } catch (error) {
+      console.error(error);
+      setFeedback({
+        type: "error",
+        message:
+          error instanceof Error ? error.message : "No se pudo actualizar el equipo",
+      });
+    } finally {
+      setAccionEnProgreso(null);
+    }
+  }
+
+  async function manejarInvitacionMiembro() {
+    if (!equipoEditando) {
+      return;
+    }
+
+    const usuarioId = Number(invitadoAAgregar);
+    if (!Number.isInteger(usuarioId) || usuarioId <= 0) {
+      setFeedback({ type: "error", message: "Selecciona un usuario válido" });
+      return;
+    }
+
+    setAccionEnProgreso(`invitar-${equipoEditando.id}`);
+    setFeedback(null);
+    try {
+      const respuesta = await fetch(`/api/equipos/${equipoEditando.id}/miembros`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ usuarioId }),
+      });
+
+      const datos = await respuesta.json();
+      if (!respuesta.ok) {
+        throw new Error(datos.error ?? "No se pudo enviar la invitación");
+      }
+
+      setFeedback({
+        type: "success",
+        message: datos.message ?? "Invitación enviada correctamente",
+      });
+      setInvitadoAAgregar("");
+      await cargarDetalleEquipo(equipoEditando.id);
+    } catch (error) {
+      console.error(error);
+      setFeedback({
+        type: "error",
+        message:
+          error instanceof Error ? error.message : "No se pudo enviar la invitación",
+      });
+    } finally {
+      setAccionEnProgreso(null);
+    }
+  }
+
+  async function manejarEliminarMiembro(miembro: MiembroEquipoDetalle) {
+    if (!equipoEditando) {
+      return;
+    }
+
+    if (!window.confirm(`¿Deseas eliminar a ${miembro.nombre} del equipo?`)) {
+      return;
+    }
+
+    setAccionEnProgreso(`eliminar-miembro-${miembro.id}`);
+    setFeedback(null);
+    try {
+      const respuesta = await fetch(
+        `/api/equipos/${equipoEditando.id}/miembros/${miembro.id}`,
+        { method: "DELETE" }
+      );
+      const datos = await respuesta.json();
+      if (!respuesta.ok) {
+        throw new Error(datos.error ?? "No se pudo eliminar al miembro");
+      }
+
+      setEquipoEditando((prev) =>
+        prev
+          ? { ...prev, miembros: prev.miembros.filter((item) => item.id !== miembro.id) }
+          : prev
+      );
+
+      if (miembro.estado === "aceptado") {
+        setEquipos((prev) =>
+          prev.map((equipo) =>
+            equipo.id === equipoEditando.id
+              ? { ...equipo, miembros: Math.max(0, equipo.miembros - 1) }
+              : equipo
+          )
+        );
+      }
+
+      setFeedback({
+        type: "success",
+        message: datos.message ?? "Miembro eliminado del equipo",
+      });
+    } catch (error) {
+      console.error(error);
+      setFeedback({
+        type: "error",
+        message:
+          error instanceof Error ? error.message : "No se pudo eliminar al miembro",
+      });
+    } finally {
+      setAccionEnProgreso(null);
+    }
+  }
+
+  async function manejarEliminarEquipo(equipoId: number) {
+    if (!window.confirm("Esta acción eliminará el equipo para todos sus miembros. ¿Continuar?")) {
+      return;
+    }
+
+    setAccionEnProgreso(`eliminar-equipo-${equipoId}`);
+    setFeedback(null);
+    try {
+      const respuesta = await fetch(`/api/equipos/${equipoId}`, { method: "DELETE" });
+      const datos = await respuesta.json();
+      if (!respuesta.ok) {
+        throw new Error(datos.error ?? "No se pudo eliminar el equipo");
+      }
+
+      setEquipos((prev) => prev.filter((equipo) => equipo.id !== equipoId));
+      if (equipoSeleccionadoId === equipoId) {
+        cerrarModalEdicion();
+      }
+      setFeedback({
+        type: "success",
+        message: datos.message ?? "Equipo eliminado correctamente",
+      });
+    } catch (error) {
+      console.error(error);
+      setFeedback({
+        type: "error",
+        message:
+          error instanceof Error ? error.message : "No se pudo eliminar el equipo",
+      });
+    } finally {
+      setAccionEnProgreso(null);
+    }
+  }
+
+  async function manejarAbandonarEquipo(equipoId: number) {
+    if (!window.confirm("¿Seguro que deseas abandonar este equipo?")) {
+      return;
+    }
+
+    setAccionEnProgreso(`abandonar-${equipoId}`);
+    setFeedback(null);
+    try {
+      const respuesta = await fetch(`/api/equipos/${equipoId}/abandonar`, {
+        method: "POST",
+      });
+      const datos = await respuesta.json();
+      if (!respuesta.ok) {
+        throw new Error(datos.error ?? "No se pudo abandonar el equipo");
+      }
+
+      setEquipos((prev) => prev.filter((equipo) => equipo.id !== equipoId));
+      setFeedback({
+        type: "success",
+        message: datos.message ?? "Has abandonado el equipo",
+      });
+    } catch (error) {
+      console.error(error);
+      setFeedback({
+        type: "error",
+        message:
+          error instanceof Error ? error.message : "No se pudo abandonar el equipo",
+      });
+    } finally {
+      setAccionEnProgreso(null);
+    }
+  }
+
+  const miembrosActualesIds = new Set(
+    (equipoEditando?.miembros ?? []).map((miembro) => miembro.id_usuario)
+  );
+  const usuariosDisponibles = usuarios.filter(
+    (usuario) => !miembrosActualesIds.has(usuario.id)
+  );
+
   return (
     <div className="space-y-10">
       <div className="flex flex-col gap-3">
@@ -238,25 +632,69 @@ export default function EquiposPage() {
                   <th className="px-4 py-3">Creado por</th>
                   <th className="px-4 py-3">Fecha de creación</th>
                   <th className="px-4 py-3 text-center">Miembros</th>
+                  <th className="px-4 py-3 text-right">Acciones</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-100">
-                {equipos.map((equipo) => (
-                  <tr key={equipo.id} className="hover:bg-gray-50">
-                    <td className="px-4 py-3 font-medium text-gray-900">
-                      {equipo.nombre}
-                    </td>
-                    <td className="px-4 py-3 text-gray-600">
-                      {equipo.creador_nombre ?? "Desconocido"}
-                    </td>
-                    <td className="px-4 py-3 text-gray-600">
-                      {formatearFecha(equipo.creado_en)}
-                    </td>
-                    <td className="px-4 py-3 text-center text-gray-600">
-                      {equipo.miembros}
-                    </td>
-                  </tr>
-                ))}
+                {equipos.map((equipo) => {
+                  const esAdministrador = equipo.rol === "administrador";
+                  return (
+                    <tr key={equipo.id} className="hover:bg-gray-50">
+                      <td className="px-4 py-3 font-medium text-gray-900">
+                        <div className="flex items-center gap-2">
+                          <span>{equipo.nombre}</span>
+                          {esAdministrador && (
+                            <span className="rounded-full bg-indigo-100 px-2 py-0.5 text-xs font-semibold text-indigo-700">
+                              Administras
+                            </span>
+                          )}
+                        </div>
+                      </td>
+                      <td className="px-4 py-3 text-gray-600">
+                        {equipo.creador_nombre ?? "Desconocido"}
+                      </td>
+                      <td className="px-4 py-3 text-gray-600">
+                        {formatearFecha(equipo.creado_en)}
+                      </td>
+                      <td className="px-4 py-3 text-center text-gray-600">
+                        {equipo.miembros}
+                      </td>
+                      <td className="px-4 py-3">
+                        {esAdministrador ? (
+                          <div className="flex justify-end gap-2">
+                            <button
+                              onClick={() => abrirModalEdicion(equipo.id)}
+                              className="rounded-md border border-gray-300 px-3 py-1.5 text-xs font-semibold text-gray-700 transition hover:bg-gray-50"
+                            >
+                              Editar
+                            </button>
+                            <button
+                              onClick={() => manejarEliminarEquipo(equipo.id)}
+                              disabled={estaProcesando(`eliminar-equipo-${equipo.id}`)}
+                              className={`rounded-md bg-red-600 px-3 py-1.5 text-xs font-semibold text-white transition hover:bg-red-700 disabled:cursor-not-allowed disabled:bg-red-400`}
+                            >
+                              {estaProcesando(`eliminar-equipo-${equipo.id}`)
+                                ? "Eliminando…"
+                                : "Eliminar"}
+                            </button>
+                          </div>
+                        ) : (
+                          <div className="flex justify-end">
+                            <button
+                              onClick={() => manejarAbandonarEquipo(equipo.id)}
+                              disabled={estaProcesando(`abandonar-${equipo.id}`)}
+                              className="rounded-md border border-red-200 px-3 py-1.5 text-xs font-semibold text-red-600 transition hover:bg-red-50 disabled:cursor-not-allowed disabled:border-red-100 disabled:text-red-300"
+                            >
+                              {estaProcesando(`abandonar-${equipo.id}`)
+                                ? "Saliendo…"
+                                : "Abandonar"}
+                            </button>
+                          </div>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           </div>
@@ -379,6 +817,177 @@ export default function EquiposPage() {
           </div>
         </form>
       </section>
+
+      {modalEdicionAbierta && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4 py-6">
+          <div className="w-full max-w-2xl rounded-xl bg-white p-6 shadow-xl">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h3 className="text-lg font-semibold text-gray-900">Editar equipo</h3>
+                {equipoEditando && (
+                  <p className="text-sm text-gray-500">
+                    Gestiona el nombre y los miembros del equipo.
+                  </p>
+                )}
+              </div>
+              <button
+                type="button"
+                onClick={cerrarModalEdicion}
+                className="rounded-md border border-gray-300 px-3 py-1.5 text-xs font-semibold text-gray-600 transition hover:bg-gray-50"
+              >
+                Cerrar
+              </button>
+            </div>
+
+            {cargandoDetalle || !equipoEditando ? (
+              <div className="py-12 text-center text-sm text-gray-500">Cargando información…</div>
+            ) : (
+              <div className="mt-6 space-y-6">
+                <form onSubmit={manejarEdicionNombre} className="space-y-2">
+                  <label htmlFor="nombre-edicion" className="block text-sm font-medium text-gray-700">
+                    Nombre del equipo
+                  </label>
+                  <input
+                    id="nombre-edicion"
+                    type="text"
+                    value={nuevoNombreEquipo}
+                    onChange={(event) => setNuevoNombreEquipo(event.target.value)}
+                    className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                  />
+                  <div className="flex justify-end">
+                    <button
+                      type="submit"
+                      disabled={estaProcesando(`renombrar-${equipoEditando.id}`)}
+                      className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-indigo-700 disabled:cursor-not-allowed disabled:bg-indigo-400"
+                    >
+                      {estaProcesando(`renombrar-${equipoEditando.id}`)
+                        ? "Guardando…"
+                        : "Guardar cambios"}
+                    </button>
+                  </div>
+                </form>
+
+                <div className="space-y-3">
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+                    <div>
+                      <h4 className="text-sm font-semibold text-gray-900">Miembros del equipo</h4>
+                      <p className="text-xs text-gray-500">
+                        Administra las invitaciones y la composición del equipo.
+                      </p>
+                    </div>
+                    <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                      <select
+                        value={invitadoAAgregar}
+                        onChange={(event) => setInvitadoAAgregar(event.target.value)}
+                        className="min-w-[220px] rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                      >
+                        <option value="" disabled>
+                          {usuariosDisponibles.length
+                            ? "Selecciona un usuario"
+                            : "No hay usuarios disponibles"}
+                        </option>
+                        {usuariosDisponibles.map((usuario) => (
+                          <option key={usuario.id} value={usuario.id}>
+                            {usuario.nombre} · {usuario.correo}
+                          </option>
+                        ))}
+                      </select>
+                      <button
+                        type="button"
+                        onClick={manejarInvitacionMiembro}
+                        disabled={
+                          !invitadoAAgregar || estaProcesando(`invitar-${equipoEditando.id}`)
+                        }
+                        className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-indigo-700 disabled:cursor-not-allowed disabled:bg-indigo-400"
+                      >
+                        {estaProcesando(`invitar-${equipoEditando.id}`)
+                          ? "Enviando…"
+                          : "Invitar"}
+                      </button>
+                    </div>
+                  </div>
+
+                  <div className="max-h-64 space-y-3 overflow-y-auto pr-2">
+                    {equipoEditando.miembros.length === 0 ? (
+                      <p className="text-sm text-gray-500">
+                        Aún no hay miembros en este equipo.
+                      </p>
+                    ) : (
+                      equipoEditando.miembros.map((miembro) => (
+                        <div
+                          key={miembro.id}
+                          className="flex flex-col gap-2 rounded-lg border border-gray-100 bg-gray-50 p-4 sm:flex-row sm:items-center sm:justify-between"
+                        >
+                          <div>
+                            <p className="text-sm font-semibold text-gray-900">{miembro.nombre}</p>
+                            <p className="text-xs text-gray-600">{miembro.correo}</p>
+                          </div>
+                          <div className="flex items-center gap-2">
+                            <span
+                              className={`rounded-full px-2 py-0.5 text-xs font-semibold ${
+                                miembro.rol === "administrador"
+                                  ? "bg-indigo-100 text-indigo-700"
+                                  : "bg-blue-100 text-blue-700"
+                              }`}
+                            >
+                              {miembro.rol === "administrador" ? "Administrador" : "Miembro"}
+                            </span>
+                            <span
+                              className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                                miembro.estado === "aceptado"
+                                  ? "bg-green-100 text-green-700"
+                                  : miembro.estado === "pendiente"
+                                  ? "bg-yellow-100 text-yellow-800"
+                                  : "bg-red-100 text-red-700"
+                              }`}
+                            >
+                              {miembro.estado === "aceptado"
+                                ? "Aceptado"
+                                : miembro.estado === "pendiente"
+                                ? "Pendiente"
+                                : "Rechazado"}
+                            </span>
+                            {miembro.rol !== "administrador" && (
+                              <button
+                                type="button"
+                                onClick={() => manejarEliminarMiembro(miembro)}
+                                disabled={estaProcesando(`eliminar-miembro-${miembro.id}`)}
+                                className="rounded-md border border-red-200 px-3 py-1 text-xs font-semibold text-red-600 transition hover:bg-red-50 disabled:cursor-not-allowed disabled:border-red-100 disabled:text-red-300"
+                              >
+                                {estaProcesando(`eliminar-miembro-${miembro.id}`)
+                                  ? "Quitando…"
+                                  : "Eliminar"}
+                              </button>
+                            )}
+                          </div>
+                        </div>
+                      ))
+                    )}
+                  </div>
+                </div>
+
+                <div className="flex flex-col gap-3 border-t border-gray-100 pt-4 sm:flex-row sm:items-center sm:justify-between">
+                  <button
+                    type="button"
+                    onClick={() => equipoEditando && manejarEliminarEquipo(equipoEditando.id)}
+                    disabled={
+                      !equipoEditando || estaProcesando(`eliminar-equipo-${equipoEditando?.id}`)
+                    }
+                    className="rounded-md bg-red-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-red-700 disabled:cursor-not-allowed disabled:bg-red-400"
+                  >
+                    {estaProcesando(`eliminar-equipo-${equipoEditando.id}`)
+                      ? "Eliminando…"
+                      : "Eliminar equipo"}
+                  </button>
+                  <p className="text-xs text-gray-500">
+                    Solo el administrador puede eliminar el equipo o a sus miembros.
+                  </p>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/app/api/equipos/[id]/abandonar/route.ts
+++ b/frontend/app/api/equipos/[id]/abandonar/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from "next/server";
+import { getUserFromSession } from "@/lib/auth";
+import { db } from "@/lib/db";
+
+type RolMiembro = "administrador" | "miembro";
+type EstadoMiembro = "pendiente" | "aceptado" | "rechazado";
+
+interface RelacionMiembroRow {
+  id: number;
+  rol: RolMiembro;
+  estado: EstadoMiembro;
+}
+
+function parseId(raw: string) {
+  const value = Number(raw);
+  return Number.isInteger(value) && value > 0 ? value : null;
+}
+
+async function obtenerRelacionMiembro(equipoId: number, usuarioId: number) {
+  return db.get<RelacionMiembroRow>(
+    `SELECT id, rol, estado
+       FROM miembros_equipo
+      WHERE id_equipo = ? AND id_usuario = ?`,
+    [equipoId, usuarioId]
+  );
+}
+
+export async function POST(
+  _request: Request,
+  context: { params: Promise<{ id: string }> }
+) {
+  try {
+    const user = await getUserFromSession();
+    if (!user) {
+      return NextResponse.json({ error: "No autenticado" }, { status: 401 });
+    }
+
+    const params = await context.params;
+    const equipoId = parseId(params.id);
+    if (!equipoId) {
+      return NextResponse.json({ error: "Equipo inválido" }, { status: 400 });
+    }
+
+    const relacion = await obtenerRelacionMiembro(equipoId, user.id);
+    if (!relacion || relacion.estado !== "aceptado") {
+      return NextResponse.json(
+        { error: "No perteneces a este equipo" },
+        { status: 404 }
+      );
+    }
+
+    if (relacion.rol === "administrador") {
+      return NextResponse.json(
+        { error: "El administrador no puede abandonar el equipo" },
+        { status: 400 }
+      );
+    }
+
+    const eliminacion = await db.run(
+      "DELETE FROM miembros_equipo WHERE id = ?",
+      [relacion.id]
+    );
+
+    if (!eliminacion.changes) {
+      return NextResponse.json(
+        { error: "No se pudo abandonar el equipo" },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({
+      success: true,
+      message: "Has abandonado el equipo",
+    });
+  } catch (error) {
+    console.error("[POST /api/equipos/:id/abandonar]", error);
+    return NextResponse.json(
+      { error: "No se pudo abandonar el equipo" },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/app/api/equipos/[id]/miembros/[miembroId]/route.ts
+++ b/frontend/app/api/equipos/[id]/miembros/[miembroId]/route.ts
@@ -1,0 +1,119 @@
+import { NextResponse } from "next/server";
+import { getUserFromSession } from "@/lib/auth";
+import { db } from "@/lib/db";
+
+type RolMiembro = "administrador" | "miembro";
+type EstadoMiembro = "pendiente" | "aceptado" | "rechazado";
+
+interface RelacionMiembroRow {
+  id: number;
+  rol: RolMiembro;
+  estado: EstadoMiembro;
+}
+
+interface MiembroRow {
+  id: number;
+  id_usuario: number;
+  rol: RolMiembro;
+  estado: EstadoMiembro;
+}
+
+function parseId(raw: string) {
+  const value = Number(raw);
+  return Number.isInteger(value) && value > 0 ? value : null;
+}
+
+async function obtenerRelacionMiembro(equipoId: number, usuarioId: number) {
+  return db.get<RelacionMiembroRow>(
+    `SELECT id, rol, estado
+       FROM miembros_equipo
+      WHERE id_equipo = ? AND id_usuario = ?`,
+    [equipoId, usuarioId]
+  );
+}
+
+export async function DELETE(
+  _request: Request,
+  context: { params: Promise<{ id: string; miembroId: string }> }
+) {
+  try {
+    const user = await getUserFromSession();
+    if (!user) {
+      return NextResponse.json({ error: "No autenticado" }, { status: 401 });
+    }
+
+    const params = await context.params;
+    const equipoId = parseId(params.id);
+    const miembroId = parseId(params.miembroId);
+
+    if (!equipoId || !miembroId) {
+      return NextResponse.json({ error: "Identificadores inválidos" }, { status: 400 });
+    }
+
+    const relacion = await obtenerRelacionMiembro(equipoId, user.id);
+    if (!relacion || relacion.estado !== "aceptado") {
+      return NextResponse.json(
+        { error: "No se encontró el equipo" },
+        { status: 404 }
+      );
+    }
+
+    if (relacion.rol !== "administrador") {
+      return NextResponse.json(
+        { error: "No tienes permisos para eliminar miembros" },
+        { status: 403 }
+      );
+    }
+
+    const miembro = await db.get<MiembroRow>(
+      `SELECT id, id_usuario, rol, estado
+         FROM miembros_equipo
+        WHERE id = ? AND id_equipo = ?`,
+      [miembroId, equipoId]
+    );
+
+    if (!miembro) {
+      return NextResponse.json(
+        { error: "Miembro no encontrado" },
+        { status: 404 }
+      );
+    }
+
+    if (miembro.rol === "administrador") {
+      return NextResponse.json(
+        { error: "No se puede eliminar al administrador del equipo" },
+        { status: 400 }
+      );
+    }
+
+    if (miembro.id_usuario === user.id) {
+      return NextResponse.json(
+        { error: "Utiliza la opción de abandonar para salir del equipo" },
+        { status: 400 }
+      );
+    }
+
+    const eliminacion = await db.run(
+      "DELETE FROM miembros_equipo WHERE id = ?",
+      [miembroId]
+    );
+
+    if (!eliminacion.changes) {
+      return NextResponse.json(
+        { error: "No se pudo eliminar al miembro" },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({
+      success: true,
+      message: "Miembro eliminado del equipo",
+    });
+  } catch (error) {
+    console.error("[DELETE /api/equipos/:id/miembros/:miembroId]", error);
+    return NextResponse.json(
+      { error: "No se pudo eliminar al miembro" },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/app/api/equipos/[id]/miembros/route.ts
+++ b/frontend/app/api/equipos/[id]/miembros/route.ts
@@ -1,0 +1,202 @@
+import { NextResponse } from "next/server";
+import { getUserFromSession } from "@/lib/auth";
+import { db } from "@/lib/db";
+
+type RolMiembro = "administrador" | "miembro";
+type EstadoMiembro = "pendiente" | "aceptado" | "rechazado";
+
+interface RelacionMiembroRow {
+  id: number;
+  rol: RolMiembro;
+  estado: EstadoMiembro;
+}
+
+interface MiembroDetalleRow {
+  id: number;
+  id_usuario: number;
+  nombre: string;
+  correo: string;
+  rol: RolMiembro;
+  estado: EstadoMiembro;
+  invitado_en: string;
+  respondido_en: string | null;
+}
+
+interface MiembroExistenteRow {
+  id: number;
+  estado: EstadoMiembro;
+}
+
+function parseId(raw: string) {
+  const value = Number(raw);
+  return Number.isInteger(value) && value > 0 ? value : null;
+}
+
+async function obtenerRelacionMiembro(equipoId: number, usuarioId: number) {
+  return db.get<RelacionMiembroRow>(
+    `SELECT id, rol, estado
+       FROM miembros_equipo
+      WHERE id_equipo = ? AND id_usuario = ?`,
+    [equipoId, usuarioId]
+  );
+}
+
+async function obtenerMiembroDetalle(miembroId: number) {
+  return db.get<MiembroDetalleRow>(
+    `SELECT me.id,
+            me.id_usuario,
+            u.nombre,
+            u.correo,
+            me.rol,
+            me.estado,
+            me.invitado_en,
+            me.respondido_en
+       FROM miembros_equipo me
+       INNER JOIN usuarios u ON u.id = me.id_usuario
+      WHERE me.id = ?`,
+    [miembroId]
+  );
+}
+
+export async function POST(
+  request: Request,
+  context: { params: Promise<{ id: string }> }
+) {
+  try {
+    const user = await getUserFromSession();
+    if (!user) {
+      return NextResponse.json({ error: "No autenticado" }, { status: 401 });
+    }
+
+    const params = await context.params;
+    const equipoId = parseId(params.id);
+    if (!equipoId) {
+      return NextResponse.json({ error: "Equipo inválido" }, { status: 400 });
+    }
+
+    const relacion = await obtenerRelacionMiembro(equipoId, user.id);
+    if (!relacion || relacion.estado !== "aceptado") {
+      return NextResponse.json(
+        { error: "No se encontró el equipo" },
+        { status: 404 }
+      );
+    }
+
+    if (relacion.rol !== "administrador") {
+      return NextResponse.json(
+        { error: "No tienes permisos para invitar miembros" },
+        { status: 403 }
+      );
+    }
+
+    const body = await request.json().catch(() => null);
+    const usuarioId =
+      typeof body?.usuarioId === "number" ? body.usuarioId : null;
+
+    if (!usuarioId) {
+      return NextResponse.json(
+        { error: "Debes indicar un usuario válido" },
+        { status: 400 }
+      );
+    }
+
+    if (usuarioId === user.id) {
+      return NextResponse.json(
+        { error: "No puedes invitarte a ti mismo" },
+        { status: 400 }
+      );
+    }
+
+    const invitado = await db.get<{ id: number }>(
+      "SELECT id FROM usuarios WHERE id = ?",
+      [usuarioId]
+    );
+
+    if (!invitado) {
+      return NextResponse.json(
+        { error: "El usuario indicado no existe" },
+        { status: 404 }
+      );
+    }
+
+    const existente = await db.get<MiembroExistenteRow>(
+      `SELECT id, estado
+         FROM miembros_equipo
+        WHERE id_equipo = ? AND id_usuario = ?`,
+      [equipoId, usuarioId]
+    );
+
+    let miembroId: number;
+
+    if (existente) {
+      if (existente.estado === "aceptado") {
+        return NextResponse.json(
+          { error: "El usuario ya es miembro del equipo" },
+          { status: 400 }
+        );
+      }
+
+      if (existente.estado === "pendiente") {
+        return NextResponse.json(
+          { error: "El usuario ya tiene una invitación pendiente" },
+          { status: 400 }
+        );
+      }
+
+      const reinvitacion = await db.run(
+        `UPDATE miembros_equipo
+            SET estado = 'pendiente',
+                rol = 'miembro',
+                invitado_por = ?,
+                invitado_en = CURRENT_TIMESTAMP,
+                respondido_en = NULL
+          WHERE id = ?`,
+        [user.id, existente.id]
+      );
+
+      if (!reinvitacion.changes) {
+        return NextResponse.json(
+          { error: "No se pudo actualizar la invitación" },
+          { status: 500 }
+        );
+      }
+
+      miembroId = existente.id;
+    } else {
+      const insercion = await db.run(
+        `INSERT INTO miembros_equipo (
+            id_equipo,
+            id_usuario,
+            rol,
+            estado,
+            invitado_por,
+            respondido_en
+          ) VALUES (?, ?, 'miembro', 'pendiente', ?, NULL)`,
+        [equipoId, usuarioId, user.id]
+      );
+
+      if (!insercion.lastID) {
+        return NextResponse.json(
+          { error: "No se pudo crear la invitación" },
+          { status: 500 }
+        );
+      }
+
+      miembroId = Number(insercion.lastID);
+    }
+
+    const miembro = await obtenerMiembroDetalle(miembroId);
+
+    return NextResponse.json({
+      success: true,
+      miembro,
+      message: "Invitación enviada correctamente",
+    });
+  } catch (error) {
+    console.error("[POST /api/equipos/:id/miembros]", error);
+    return NextResponse.json(
+      { error: "No se pudo agregar al miembro" },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/app/api/equipos/[id]/route.ts
+++ b/frontend/app/api/equipos/[id]/route.ts
@@ -1,0 +1,250 @@
+import { NextResponse } from "next/server";
+import { getUserFromSession } from "@/lib/auth";
+import { db } from "@/lib/db";
+
+type RolMiembro = "administrador" | "miembro";
+type EstadoMiembro = "pendiente" | "aceptado" | "rechazado";
+
+interface RelacionMiembroRow {
+  id: number;
+  rol: RolMiembro;
+  estado: EstadoMiembro;
+}
+
+interface EquipoDetalleRow {
+  id: number;
+  nombre: string;
+  creado_en: string;
+  creado_por: number;
+  creador_nombre: string | null;
+}
+
+interface MiembroDetalleRow {
+  id: number;
+  id_usuario: number;
+  nombre: string;
+  correo: string;
+  rol: RolMiembro;
+  estado: EstadoMiembro;
+  invitado_en: string;
+  respondido_en: string | null;
+}
+
+async function obtenerRelacionMiembro(equipoId: number, usuarioId: number) {
+  return db.get<RelacionMiembroRow>(
+    `SELECT id, rol, estado
+       FROM miembros_equipo
+      WHERE id_equipo = ? AND id_usuario = ?`,
+    [equipoId, usuarioId]
+  );
+}
+
+async function obtenerEquipo(equipoId: number) {
+  return db.get<EquipoDetalleRow>(
+    `SELECT e.id, e.nombre, e.creado_en, e.creado_por, c.nombre AS creador_nombre
+       FROM equipos e
+       LEFT JOIN usuarios c ON c.id = e.creado_por
+      WHERE e.id = ?`,
+    [equipoId]
+  );
+}
+
+async function obtenerMiembros(equipoId: number) {
+  return db.all<MiembroDetalleRow>(
+    `SELECT me.id,
+            me.id_usuario,
+            u.nombre,
+            u.correo,
+            me.rol,
+            me.estado,
+            me.invitado_en,
+            me.respondido_en
+       FROM miembros_equipo me
+       INNER JOIN usuarios u ON u.id = me.id_usuario
+      WHERE me.id_equipo = ?
+        AND me.estado IN ('aceptado', 'pendiente')
+      ORDER BY CASE WHEN me.rol = 'administrador' THEN 0 ELSE 1 END,
+               u.nombre COLLATE NOCASE`,
+    [equipoId]
+  );
+}
+
+function parseId(raw: string) {
+  const value = Number(raw);
+  return Number.isInteger(value) && value > 0 ? value : null;
+}
+
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ id: string }> }
+) {
+  try {
+    const user = await getUserFromSession();
+    if (!user) {
+      return NextResponse.json({ error: "No autenticado" }, { status: 401 });
+    }
+
+    const params = await context.params;
+    const equipoId = parseId(params.id);
+    if (!equipoId) {
+      return NextResponse.json({ error: "Equipo inválido" }, { status: 400 });
+    }
+
+    const relacion = await obtenerRelacionMiembro(equipoId, user.id);
+    if (!relacion || relacion.estado !== "aceptado") {
+      return NextResponse.json(
+        { error: "No se encontró el equipo" },
+        { status: 404 }
+      );
+    }
+
+    if (relacion.rol !== "administrador") {
+      return NextResponse.json(
+        { error: "No tienes permisos para gestionar este equipo" },
+        { status: 403 }
+      );
+    }
+
+    const equipo = await obtenerEquipo(equipoId);
+    if (!equipo) {
+      return NextResponse.json(
+        { error: "Equipo no encontrado" },
+        { status: 404 }
+      );
+    }
+
+    const miembros = await obtenerMiembros(equipoId);
+
+    return NextResponse.json({ equipo, miembros });
+  } catch (error) {
+    console.error("[GET /api/equipos/:id]", error);
+    return NextResponse.json(
+      { error: "Error al obtener la información del equipo" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PATCH(
+  request: Request,
+  context: { params: Promise<{ id: string }> }
+) {
+  try {
+    const user = await getUserFromSession();
+    if (!user) {
+      return NextResponse.json({ error: "No autenticado" }, { status: 401 });
+    }
+
+    const params = await context.params;
+    const equipoId = parseId(params.id);
+    if (!equipoId) {
+      return NextResponse.json({ error: "Equipo inválido" }, { status: 400 });
+    }
+
+    const relacion = await obtenerRelacionMiembro(equipoId, user.id);
+    if (!relacion || relacion.estado !== "aceptado") {
+      return NextResponse.json(
+        { error: "No se encontró el equipo" },
+        { status: 404 }
+      );
+    }
+
+    if (relacion.rol !== "administrador") {
+      return NextResponse.json(
+        { error: "No tienes permisos para editar este equipo" },
+        { status: 403 }
+      );
+    }
+
+    const body = await request.json().catch(() => ({}));
+    const nombre =
+      typeof body?.nombre === "string" ? body.nombre.trim() : "";
+
+    if (!nombre) {
+      return NextResponse.json(
+        { error: "El nombre del equipo es obligatorio" },
+        { status: 400 }
+      );
+    }
+
+    await db.run("UPDATE equipos SET nombre = ? WHERE id = ?", [
+      nombre,
+      equipoId,
+    ]);
+
+    const equipoActualizado = await obtenerEquipo(equipoId);
+    if (!equipoActualizado) {
+      return NextResponse.json(
+        { error: "Equipo no encontrado tras la actualización" },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({
+      success: true,
+      equipo: equipoActualizado,
+      message: "Equipo actualizado correctamente",
+    });
+  } catch (error) {
+    console.error("[PATCH /api/equipos/:id]", error);
+    return NextResponse.json(
+      { error: "No se pudo actualizar el equipo" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(
+  _request: Request,
+  context: { params: Promise<{ id: string }> }
+) {
+  try {
+    const user = await getUserFromSession();
+    if (!user) {
+      return NextResponse.json({ error: "No autenticado" }, { status: 401 });
+    }
+
+    const params = await context.params;
+    const equipoId = parseId(params.id);
+    if (!equipoId) {
+      return NextResponse.json({ error: "Equipo inválido" }, { status: 400 });
+    }
+
+    const relacion = await obtenerRelacionMiembro(equipoId, user.id);
+    if (!relacion || relacion.estado !== "aceptado") {
+      return NextResponse.json(
+        { error: "No se encontró el equipo" },
+        { status: 404 }
+      );
+    }
+
+    if (relacion.rol !== "administrador") {
+      return NextResponse.json(
+        { error: "No tienes permisos para eliminar este equipo" },
+        { status: 403 }
+      );
+    }
+
+    const eliminacion = await db.run("DELETE FROM equipos WHERE id = ?", [
+      equipoId,
+    ]);
+
+    if (!eliminacion.changes) {
+      return NextResponse.json(
+        { error: "No se pudo eliminar el equipo" },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({
+      success: true,
+      message: "Equipo eliminado correctamente",
+    });
+  } catch (error) {
+    console.error("[DELETE /api/equipos/:id]", error);
+    return NextResponse.json(
+      { error: "No se pudo eliminar el equipo" },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/app/api/equipos/route.ts
+++ b/frontend/app/api/equipos/route.ts
@@ -9,6 +9,7 @@ interface EquipoRow {
   creado_por: number;
   creador_nombre: string | null;
   miembros: number;
+  rol_usuario: "administrador" | "miembro";
 }
 
 export async function GET() {
@@ -25,6 +26,7 @@ export async function GET() {
         e.creado_en,
         e.creado_por,
         c.nombre AS creador_nombre,
+        me.rol AS rol_usuario,
         (
           SELECT COUNT(*)
           FROM miembros_equipo me2

--- a/frontend/lib/db.ts
+++ b/frontend/lib/db.ts
@@ -72,6 +72,30 @@ function initializeTeamSchema(database: SqliteDatabase) {
     );
 
     database.run(
+      "CREATE INDEX IF NOT EXISTS idx_miembros_equipo ON miembros_equipo(id_equipo)",
+      (error) => {
+        if (error) {
+          console.error(
+            "[DB] Error creando el índice idx_miembros_equipo",
+            error
+          );
+        }
+      }
+    );
+
+    database.run(
+      "CREATE INDEX IF NOT EXISTS idx_miembros_equipo_usuario ON miembros_equipo(id_usuario)",
+      (error) => {
+        if (error) {
+          console.error(
+            "[DB] Error creando el índice idx_miembros_equipo_usuario",
+            error
+          );
+        }
+      }
+    );
+
+    database.run(
       "ALTER TABLE eventos_internos ADD COLUMN id_equipo INTEGER REFERENCES equipos(id) ON DELETE SET NULL",
       (error) => {
         if (error && !String(error.message).includes("duplicate column name")) {


### PR DESCRIPTION
## Summary
- add missing SQLite index creation for equipo membership lookups
- expose granular team management API endpoints for renaming, member invites, removals, and leaving teams
- enhance the teams panel so admins can edit teams and members while regular users can leave teams

## Testing
- npm run lint *(fails: Next.js lint runner expects /lint directory in this project configuration)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916469398808327ad9a2022fa51a70e)