### PR TITLE
Enhance settings page with profile and theme management

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -15,6 +15,7 @@ CREATE TABLE IF NOT EXISTS usuarios (
     correo          VARCHAR(150) UNIQUE NOT NULL,
     password_hash   TEXT NOT NULL,
     zona_horaria    VARCHAR(50) DEFAULT 'America/Mexico_City',
+    tema_preferencia TEXT CHECK(tema_preferencia IN ('light','dark','auto')) DEFAULT 'auto',
     creado_en       DATETIME DEFAULT CURRENT_TIMESTAMP
 );
 

--- a/frontend/app/(panel)/configuracion/page.tsx
+++ b/frontend/app/(panel)/configuracion/page.tsx
@@ -1,11 +1,438 @@
 "use client";
 
-// Página temporal del módulo de Configuración dentro del panel administrativo.
-export default function Page() {
+import { FormEvent, useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import useSWR from "@/lib/swr";
+import { ThemePreference, useTheme } from "@/components/ThemeProvider";
+
+interface MeResponse {
+  id: number;
+  name: string;
+  email: string;
+  timezone: string | null;
+  themePreference: ThemePreference;
+}
+
+interface UpdateProfileResponse {
+  ok: boolean;
+  user: MeResponse;
+  error?: string;
+}
+
+interface BasicResponse {
+  ok?: boolean;
+  error?: string;
+}
+
+const fetcher = async (url: string): Promise<MeResponse> => {
+  const response = await fetch(url, { credentials: "include" });
+
+  if (!response.ok) {
+    throw new Error("No se pudo cargar la información del perfil");
+  }
+
+  return (await response.json()) as MeResponse;
+};
+
+const themeOptions: { value: ThemePreference; label: string; description: string }[] = [
+  {
+    value: "auto",
+    label: "Automático",
+    description:
+      "Detecta el mejor tema según la hora del día y cambia entre claro y oscuro automáticamente.",
+  },
+  {
+    value: "light",
+    label: "Claro",
+    description: "Usa siempre el modo claro, ideal para ambientes bien iluminados.",
+  },
+  {
+    value: "dark",
+    label: "Oscuro",
+    description: "Mantiene un contraste bajo para trabajar mejor de noche.",
+  },
+];
+
+export default function ConfiguracionPage() {
+  const router = useRouter();
+  const { preference, resolvedTheme, setPreference } = useTheme();
+
+  const { data, error, isLoading, mutate } = useSWR<MeResponse>(
+    "/api/me",
+    fetcher,
+    { revalidateOnFocus: false }
+  );
+
+  const [name, setName] = useState("");
+  const [themePreference, setThemePreference] = useState<ThemePreference>("auto");
+  const [profileMessage, setProfileMessage] = useState<
+    { type: "success" | "error"; text: string } | null
+  >(null);
+  const [isSavingProfile, setIsSavingProfile] = useState(false);
+
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [passwordMessage, setPasswordMessage] = useState<
+    { type: "success" | "error"; text: string } | null
+  >(null);
+  const [isSavingPassword, setIsSavingPassword] = useState(false);
+
+  const [logoutMessage, setLogoutMessage] = useState<string | null>(null);
+  const [isLoggingOut, setIsLoggingOut] = useState(false);
+
+  useEffect(() => {
+    if (!data) {
+      return;
+    }
+
+    setName(data.name);
+    setThemePreference(data.themePreference);
+
+    if (data.themePreference && data.themePreference !== preference) {
+      setPreference(data.themePreference);
+    }
+  }, [data, preference, setPreference]);
+
+  const handleProfileSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setProfileMessage(null);
+    setIsSavingProfile(true);
+
+    try {
+      const response = await fetch("/api/me/profile", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name, themePreference }),
+      });
+
+      const payload = (await response.json().catch(() => ({}))) as UpdateProfileResponse;
+
+      if (!response.ok || !payload?.ok || !payload.user) {
+        const message = payload?.error ?? "No fue posible guardar los cambios.";
+        setProfileMessage({ type: "error", text: message });
+        return;
+      }
+
+      mutate(payload.user, false).catch(() => undefined);
+      setPreference(payload.user.themePreference);
+      setProfileMessage({ type: "success", text: "Perfil actualizado correctamente." });
+    } catch (err) {
+      console.error("[Configuración] Error al actualizar perfil", err);
+      setProfileMessage({
+        type: "error",
+        text: "Ocurrió un error inesperado. Intenta de nuevo en unos minutos.",
+      });
+    } finally {
+      setIsSavingProfile(false);
+    }
+  };
+
+  const handlePasswordSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setPasswordMessage(null);
+
+    if (newPassword !== confirmPassword) {
+      setPasswordMessage({
+        type: "error",
+        text: "La confirmación de la nueva contraseña no coincide.",
+      });
+      return;
+    }
+
+    if (newPassword.length < 8) {
+      setPasswordMessage({
+        type: "error",
+        text: "La nueva contraseña debe tener al menos 8 caracteres.",
+      });
+      return;
+    }
+
+    setIsSavingPassword(true);
+
+    try {
+      const response = await fetch("/api/me/password", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ currentPassword, newPassword, confirmPassword }),
+      });
+
+      const payload = (await response.json().catch(() => ({}))) as BasicResponse;
+
+      if (!response.ok || !payload?.ok) {
+        const message = payload?.error ?? "No fue posible cambiar la contraseña.";
+        setPasswordMessage({ type: "error", text: message });
+        return;
+      }
+
+      setCurrentPassword("");
+      setNewPassword("");
+      setConfirmPassword("");
+      setPasswordMessage({ type: "success", text: "Contraseña actualizada correctamente." });
+    } catch (err) {
+      console.error("[Configuración] Error al cambiar contraseña", err);
+      setPasswordMessage({
+        type: "error",
+        text: "Ocurrió un error inesperado. Intenta nuevamente más tarde.",
+      });
+    } finally {
+      setIsSavingPassword(false);
+    }
+  };
+
+  const handleLogout = async () => {
+    setLogoutMessage(null);
+    setIsLoggingOut(true);
+
+    try {
+      const response = await fetch("/api/logout", { method: "POST" });
+      if (!response.ok) {
+        throw new Error("Logout failed");
+      }
+
+      setPreference("auto");
+      mutate(undefined, false).catch(() => undefined);
+      router.push("/login");
+      router.refresh();
+    } catch (err) {
+      console.error("[Configuración] Error al cerrar sesión", err);
+      setLogoutMessage("No fue posible cerrar sesión. Intenta nuevamente.");
+    } finally {
+      setIsLoggingOut(false);
+    }
+  };
+
+  const isProfileDisabled = isLoading || !data;
+
+  const resolvedThemeDescription = useMemo(() => {
+    if (themePreference !== "auto") {
+      return "";
+    }
+
+    return resolvedTheme === "dark"
+      ? "Actualmente se usa el modo oscuro por el horario."
+      : "Actualmente se usa el modo claro por el horario.";
+  }, [resolvedTheme, themePreference]);
+
   return (
-    <div className="flex h-full flex-col items-center justify-center text-center">
-      <h1 className="mb-2 text-2xl font-semibold">Aquí va la página de Configuración</h1>
-      <p className="text-gray-500">Estamos en proceso 🚧</p>
+    <div className="mx-auto flex w-full max-w-4xl flex-col gap-8 pb-12">
+      <header className="flex flex-col gap-2">
+        <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-50">Ajustes de la cuenta</h1>
+        <p className="text-sm text-gray-600 dark:text-gray-300">
+          Gestiona tu información personal, credenciales y preferencias visuales.
+        </p>
+      </header>
+
+      {error ? (
+        <div className="rounded-2xl border border-red-200 bg-red-50/70 p-4 text-sm text-red-700 dark:border-red-500/40 dark:bg-red-500/10 dark:text-red-200">
+          No fue posible cargar los datos del perfil. Recarga la página.
+        </div>
+      ) : null}
+
+      <section className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm transition dark:border-gray-800 dark:bg-gray-900">
+        <div className="mb-6 flex flex-col gap-2">
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Perfil</h2>
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            Actualiza tu nombre visible y el tema que prefieres para el panel.
+          </p>
+        </div>
+        <form className="flex flex-col gap-6" onSubmit={handleProfileSubmit}>
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="name">
+              Nombre completo
+            </label>
+            <input
+              id="name"
+              name="name"
+              type="text"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              placeholder="Tu nombre"
+              className="w-full rounded-xl border border-gray-300 bg-white px-4 py-2 text-sm text-gray-900 shadow-sm transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 disabled:cursor-not-allowed disabled:bg-gray-100 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:focus:border-indigo-400 dark:focus:ring-indigo-500/30"
+              disabled={isProfileDisabled}
+              required
+            />
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="email">
+              Correo electrónico
+            </label>
+            <input
+              id="email"
+              type="email"
+              value={data?.email ?? ""}
+              disabled
+              className="w-full rounded-xl border border-gray-200 bg-gray-100 px-4 py-2 text-sm text-gray-500 shadow-inner dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400"
+            />
+          </div>
+
+          <fieldset className="flex flex-col gap-3">
+            <legend className="text-sm font-medium text-gray-700 dark:text-gray-200">
+              Tema del panel
+            </legend>
+            <div className="grid gap-3 md:grid-cols-3">
+              {themeOptions.map((option) => {
+                const isChecked = themePreference === option.value;
+                return (
+                  <label
+                    key={option.value}
+                    className={`flex cursor-pointer flex-col gap-1 rounded-2xl border p-4 text-sm transition ${
+                      isChecked
+                        ? "border-indigo-400 bg-indigo-50/70 text-indigo-700 dark:border-indigo-400 dark:bg-indigo-500/10 dark:text-indigo-200"
+                        : "border-gray-200 bg-white text-gray-600 hover:border-indigo-300 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:border-indigo-300"
+                    }`}
+                  >
+                    <input
+                      type="radio"
+                      name="themePreference"
+                      value={option.value}
+                      checked={isChecked}
+                      onChange={() => setThemePreference(option.value)}
+                      className="sr-only"
+                      disabled={isProfileDisabled}
+                    />
+                    <span className="text-sm font-semibold">{option.label}</span>
+                    <span className="text-xs leading-relaxed text-gray-500 dark:text-gray-400">
+                      {option.description}
+                    </span>
+                  </label>
+                );
+              })}
+            </div>
+            {resolvedThemeDescription ? (
+              <p className="text-xs text-gray-500 dark:text-gray-400">{resolvedThemeDescription}</p>
+            ) : null}
+          </fieldset>
+
+          {profileMessage ? (
+            <div
+              className={`rounded-xl border px-4 py-3 text-sm ${
+                profileMessage.type === "success"
+                  ? "border-emerald-200 bg-emerald-50/80 text-emerald-700 dark:border-emerald-400/40 dark:bg-emerald-500/10 dark:text-emerald-200"
+                  : "border-red-200 bg-red-50/80 text-red-700 dark:border-red-400/40 dark:bg-red-500/10 dark:text-red-200"
+              }`}
+            >
+              {profileMessage.text}
+            </div>
+          ) : null}
+
+          <div className="flex items-center justify-end gap-3">
+            <button
+              type="submit"
+              className="inline-flex items-center justify-center rounded-xl bg-indigo-600 px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-300 disabled:cursor-not-allowed disabled:bg-indigo-300"
+              disabled={isProfileDisabled || isSavingProfile}
+            >
+              {isSavingProfile ? "Guardando..." : "Guardar cambios"}
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <section className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm transition dark:border-gray-800 dark:bg-gray-900">
+        <div className="mb-6 flex flex-col gap-2">
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Cambiar contraseña</h2>
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            Asegúrate de usar una contraseña robusta y diferente a la anterior.
+          </p>
+        </div>
+
+        <form className="flex flex-col gap-6" onSubmit={handlePasswordSubmit}>
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="flex flex-col gap-2">
+              <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="currentPassword">
+                Contraseña actual
+              </label>
+              <input
+                id="currentPassword"
+                name="currentPassword"
+                type="password"
+                value={currentPassword}
+                onChange={(event) => setCurrentPassword(event.target.value)}
+                autoComplete="current-password"
+                className="w-full rounded-xl border border-gray-300 bg-white px-4 py-2 text-sm text-gray-900 shadow-sm transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:focus:border-indigo-400 dark:focus:ring-indigo-500/30"
+                required
+              />
+            </div>
+            <div className="flex flex-col gap-2">
+              <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="newPassword">
+                Nueva contraseña
+              </label>
+              <input
+                id="newPassword"
+                name="newPassword"
+                type="password"
+                value={newPassword}
+                onChange={(event) => setNewPassword(event.target.value)}
+                autoComplete="new-password"
+                className="w-full rounded-xl border border-gray-300 bg-white px-4 py-2 text-sm text-gray-900 shadow-sm transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:focus:border-indigo-400 dark:focus:ring-indigo-500/30"
+                required
+              />
+            </div>
+            <div className="flex flex-col gap-2 md:col-span-2">
+              <label className="text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="confirmPassword">
+                Confirmar nueva contraseña
+              </label>
+              <input
+                id="confirmPassword"
+                name="confirmPassword"
+                type="password"
+                value={confirmPassword}
+                onChange={(event) => setConfirmPassword(event.target.value)}
+                autoComplete="new-password"
+                className="w-full rounded-xl border border-gray-300 bg-white px-4 py-2 text-sm text-gray-900 shadow-sm transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:focus:border-indigo-400 dark:focus:ring-indigo-500/30"
+                required
+              />
+            </div>
+          </div>
+
+          {passwordMessage ? (
+            <div
+              className={`rounded-xl border px-4 py-3 text-sm ${
+                passwordMessage.type === "success"
+                  ? "border-emerald-200 bg-emerald-50/80 text-emerald-700 dark:border-emerald-400/40 dark:bg-emerald-500/10 dark:text-emerald-200"
+                  : "border-red-200 bg-red-50/80 text-red-700 dark:border-red-400/40 dark:bg-red-500/10 dark:text-red-200"
+              }`}
+            >
+              {passwordMessage.text}
+            </div>
+          ) : null}
+
+          <div className="flex items-center justify-end gap-3">
+            <button
+              type="submit"
+              className="inline-flex items-center justify-center rounded-xl bg-indigo-600 px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-300 disabled:cursor-not-allowed disabled:bg-indigo-300"
+              disabled={isSavingPassword}
+            >
+              {isSavingPassword ? "Actualizando..." : "Actualizar contraseña"}
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <section className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm transition dark:border-gray-800 dark:bg-gray-900">
+        <div className="mb-4 flex flex-col gap-2">
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Sesión</h2>
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            Puedes cerrar la sesión actual en este dispositivo cuando lo necesites.
+          </p>
+        </div>
+        <div className="flex flex-col gap-4">
+          {logoutMessage ? (
+            <div className="rounded-xl border border-red-200 bg-red-50/80 px-4 py-3 text-sm text-red-700 dark:border-red-400/40 dark:bg-red-500/10 dark:text-red-200">
+              {logoutMessage}
+            </div>
+          ) : null}
+          <button
+            type="button"
+            onClick={handleLogout}
+            className="inline-flex w-fit items-center justify-center rounded-xl border border-red-300 bg-red-50 px-5 py-2 text-sm font-semibold text-red-700 transition hover:border-red-400 hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-red-200 disabled:cursor-not-allowed disabled:opacity-70 dark:border-red-500/60 dark:bg-red-500/10 dark:text-red-200 dark:hover:border-red-400 dark:hover:bg-red-500/20"
+            disabled={isLoggingOut}
+          >
+            {isLoggingOut ? "Cerrando sesión..." : "Cerrar sesión"}
+          </button>
+        </div>
+      </section>
     </div>
   );
 }

--- a/frontend/app/(panel)/layout.tsx
+++ b/frontend/app/(panel)/layout.tsx
@@ -1,5 +1,7 @@
 import type { ReactNode } from "react";
 import Sidebar from "../../components/Sidebar";
+import { ThemeProvider } from "@/components/ThemeProvider";
+import { getUserFromSession } from "@/lib/auth";
 
 /**
  * Layout principal del panel.
@@ -7,18 +9,26 @@ import Sidebar from "../../components/Sidebar";
  * No incluye etiquetas <html> ni <body> porque esas ya están definidas en app/layout.tsx.
  * El header se ha deshabilitado temporalmente.
  */
-export default function PanelLayout({ children }: { children: ReactNode }) {
-  return (
-    <div className="flex min-h-screen w-full bg-gray-50">
-      {/* Sidebar lateral */}
-      <Sidebar />
+export default async function PanelLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const user = await getUserFromSession();
 
-      {/* Contenedor principal */}
-      <main className="flex flex-1 flex-col p-6 md:ml-64">
-        {/* Header temporalmente deshabilitado */}
-        {/* <Header /> */}
-        {children}
-      </main>
-    </div>
+  return (
+    <ThemeProvider initialPreference={user?.tema_preferencia ?? "auto"}>
+      <div className="flex min-h-screen w-full bg-gray-50 transition-colors duration-300 dark:bg-gray-950">
+        {/* Sidebar lateral */}
+        <Sidebar />
+
+        {/* Contenedor principal */}
+        <main className="flex flex-1 flex-col p-6 md:ml-64">
+          {/* Header temporalmente deshabilitado */}
+          {/* <Header /> */}
+          {children}
+        </main>
+      </div>
+    </ThemeProvider>
   );
 }

--- a/frontend/app/api/logout/route.ts
+++ b/frontend/app/api/logout/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+
+export async function POST() {
+  const response = NextResponse.json({ ok: true });
+  response.cookies.set("user_id", "", {
+    httpOnly: true,
+    sameSite: "lax",
+    path: "/",
+    secure: process.env.NODE_ENV === "production",
+    expires: new Date(0),
+  });
+
+  return response;
+}

--- a/frontend/app/api/me/password/route.ts
+++ b/frontend/app/api/me/password/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from "next/server";
+import bcrypt from "bcryptjs";
+import { getUserFromSession } from "@/lib/auth";
+import { getUserRowById, updateUserPasswordHash } from "@/lib/db";
+
+export async function PATCH(request: NextRequest) {
+  const user = await getUserFromSession();
+
+  if (!user) {
+    return NextResponse.json({ error: "No autenticado" }, { status: 401 });
+  }
+
+  const body = await request.json().catch(() => null);
+  const currentPassword =
+    typeof body?.currentPassword === "string" ? body.currentPassword : "";
+  const newPassword =
+    typeof body?.newPassword === "string" ? body.newPassword : "";
+  const confirmPassword =
+    typeof body?.confirmPassword === "string" ? body.confirmPassword : "";
+
+  if (!currentPassword || !newPassword || !confirmPassword) {
+    return NextResponse.json(
+      { error: "Todos los campos son obligatorios" },
+      { status: 400 }
+    );
+  }
+
+  if (newPassword.length < 8) {
+    return NextResponse.json(
+      { error: "La nueva contraseña debe tener al menos 8 caracteres" },
+      { status: 400 }
+    );
+  }
+
+  if (newPassword !== confirmPassword) {
+    return NextResponse.json(
+      { error: "La confirmación no coincide" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const dbUser = await getUserRowById(user.id);
+
+    if (!dbUser) {
+      return NextResponse.json(
+        { error: "Usuario no encontrado" },
+        { status: 404 }
+      );
+    }
+
+    const isPasswordValid = await bcrypt.compare(currentPassword, dbUser.password_hash);
+
+    if (!isPasswordValid) {
+      return NextResponse.json(
+        { error: "La contraseña actual es incorrecta" },
+        { status: 401 }
+      );
+    }
+
+    if (await bcrypt.compare(newPassword, dbUser.password_hash)) {
+      return NextResponse.json(
+        { error: "La nueva contraseña no puede ser igual a la actual" },
+        { status: 400 }
+      );
+    }
+
+    const newHash = await bcrypt.hash(newPassword, 10);
+    await updateUserPasswordHash(user.id, newHash);
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error("[PATCH /api/me/password]", error);
+    return NextResponse.json(
+      { error: "No fue posible actualizar la contraseña" },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/app/api/me/profile/route.ts
+++ b/frontend/app/api/me/profile/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getUserFromSession } from "@/lib/auth";
+import {
+  ThemePreference,
+  getUserById,
+  updateUserProfile,
+} from "@/lib/db";
+
+const THEME_OPTIONS: ThemePreference[] = ["light", "dark", "auto"];
+
+export async function PATCH(request: NextRequest) {
+  const user = await getUserFromSession();
+
+  if (!user) {
+    return NextResponse.json({ error: "No autenticado" }, { status: 401 });
+  }
+
+  const body = await request.json().catch(() => null);
+
+  const name =
+    typeof body?.name === "string" ? body.name.trim() : "";
+  const themePreferenceRaw =
+    typeof body?.themePreference === "string" ? body.themePreference : "";
+
+  if (!name) {
+    return NextResponse.json(
+      { error: "El nombre es obligatorio" },
+      { status: 400 }
+    );
+  }
+
+  const themePreference = (THEME_OPTIONS.includes(themePreferenceRaw as ThemePreference)
+    ? (themePreferenceRaw as ThemePreference)
+    : undefined) ?? "auto";
+
+  try {
+    await updateUserProfile(user.id, name, themePreference);
+    const updatedUser = await getUserById(user.id);
+
+    return NextResponse.json({
+      ok: true,
+      user: {
+        id: updatedUser?.id ?? user.id,
+        name: updatedUser?.nombre ?? name,
+        email: updatedUser?.correo ?? user.correo,
+        timezone: updatedUser?.zona_horaria ?? null,
+        themePreference: updatedUser?.tema_preferencia ?? themePreference,
+      },
+    });
+  } catch (error) {
+    console.error("[PATCH /api/me/profile]", error);
+    return NextResponse.json(
+      { error: "No fue posible actualizar el perfil" },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/app/api/me/route.ts
+++ b/frontend/app/api/me/route.ts
@@ -9,5 +9,11 @@ export async function GET() {
     return NextResponse.json({ error: "No autenticado" }, { status: 401 });
   }
 
-  return NextResponse.json({ id: user.id, name: user.nombre, email: user.correo });
+  return NextResponse.json({
+    id: user.id,
+    name: user.nombre,
+    email: user.correo,
+    timezone: user.zona_horaria ?? null,
+    themePreference: user.tema_preferencia ?? "auto",
+  });
 }

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -25,7 +25,9 @@ export default function RootLayout({
   return (
     <html lang="es">
       {/* Aplicamos la fuente y colores de fondo base a todo el proyecto. */}
-      <body className={`${inter.className} bg-gray-50 text-gray-900`}>
+      <body
+        className={`${inter.className} bg-gray-50 text-gray-900 transition-colors duration-300 dark:bg-gray-950 dark:text-gray-100`}
+      >
         {/* Renderizamos el contenido específico de cada página o layout anidado. */}
         {children}
       </body>

--- a/frontend/components/Sidebar.tsx
+++ b/frontend/components/Sidebar.tsx
@@ -15,12 +15,12 @@ export default function Sidebar() {
   const pathname = usePathname();
 
   return (
-    <aside className="fixed inset-y-0 left-0 z-40 hidden w-64 flex-col border-r border-gray-800 bg-gray-900 p-6 text-white shadow-xl md:flex">
+    <aside className="fixed inset-y-0 left-0 z-40 hidden w-64 flex-col border-r border-gray-200 bg-white p-6 text-gray-700 shadow-xl transition-colors duration-300 dark:border-gray-800 dark:bg-gray-900 dark:text-gray-100 md:flex">
       <div className="mb-8">
-        <span className="text-sm font-semibold uppercase tracking-widest text-indigo-400">
+        <span className="text-sm font-semibold uppercase tracking-widest text-indigo-500 dark:text-indigo-300">
           Agenda Inteligente
         </span>
-        <h2 className="mt-2 text-2xl font-bold">Panel</h2>
+        <h2 className="mt-2 text-2xl font-bold text-gray-900 dark:text-white">Panel</h2>
       </div>
       <nav className="flex flex-1 flex-col gap-1 text-sm">
         {navigation.map((item) => {
@@ -30,7 +30,9 @@ export default function Sidebar() {
               key={item.name}
               href={item.href}
               className={`flex items-center gap-3 rounded-xl px-3 py-2 transition ${
-                isActive ? "bg-gray-800 text-white" : "text-gray-300 hover:bg-gray-800/60 hover:text-white"
+                isActive
+                  ? "bg-indigo-50 text-indigo-600 dark:bg-indigo-500/20 dark:text-indigo-200"
+                  : "text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-800/60 dark:hover:text-white"
               }`}
             >
               <span className="text-lg">{item.icon}</span>
@@ -39,9 +41,9 @@ export default function Sidebar() {
           );
         })}
       </nav>
-      <div className="mt-6 rounded-xl border border-white/10 bg-white/5 p-4 text-xs text-gray-200">
-        <p className="font-semibold text-white">Sincroniza tu agenda</p>
-        <p className="mt-1 text-gray-300">
+      <div className="mt-6 rounded-xl border border-indigo-100 bg-indigo-50/60 p-4 text-xs text-indigo-900 transition dark:border-white/10 dark:bg-white/5 dark:text-gray-200">
+        <p className="font-semibold text-indigo-700 dark:text-white">Sincroniza tu agenda</p>
+        <p className="mt-1 text-indigo-600 dark:text-gray-300">
           Conecta tus cuentas para mantener tus eventos siempre actualizados.
         </p>
         <button className="mt-4 inline-flex items-center justify-center rounded-lg bg-indigo-500 px-3 py-2 text-xs font-semibold text-white transition hover:bg-indigo-400">

--- a/frontend/components/ThemeProvider.tsx
+++ b/frontend/components/ThemeProvider.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import {
+  ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+export type ThemePreference = "light" | "dark" | "auto";
+
+// Puedes ajustar los horarios en los que el modo automático cambia entre claro y oscuro.
+// Modifica las constantes `AUTO_THEME_DAY_START_HOUR` y `AUTO_THEME_NIGHT_START_HOUR`
+// según tus necesidades.
+const AUTO_THEME_DAY_START_HOUR = 7; // 7:00 am
+const AUTO_THEME_NIGHT_START_HOUR = 19; // 7:00 pm
+
+type ThemeContextValue = {
+  preference: ThemePreference;
+  resolvedTheme: "light" | "dark";
+  setPreference: (preference: ThemePreference) => void;
+};
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+function resolveTheme(preference: ThemePreference, now: Date): "light" | "dark" {
+  if (preference === "light" || preference === "dark") {
+    return preference;
+  }
+
+  const hour = now.getHours();
+  const isNight =
+    hour >= AUTO_THEME_NIGHT_START_HOUR || hour < AUTO_THEME_DAY_START_HOUR;
+
+  return isNight ? "dark" : "light";
+}
+
+interface ThemeProviderProps {
+  initialPreference?: ThemePreference | null;
+  children: ReactNode;
+}
+
+export function ThemeProvider({ children, initialPreference }: ThemeProviderProps) {
+  const [preference, setPreference] = useState<ThemePreference>(
+    initialPreference ?? "auto"
+  );
+  const [resolvedTheme, setResolvedTheme] = useState<"light" | "dark">(
+    resolveTheme(initialPreference ?? "auto", new Date())
+  );
+
+  const applyTheme = useCallback(
+    (preferenceValue: ThemePreference) => {
+      const now = new Date();
+      const theme = resolveTheme(preferenceValue, now);
+      setResolvedTheme(theme);
+
+      const root = document.documentElement;
+      root.classList.toggle("dark", theme === "dark");
+      root.setAttribute("data-theme-preference", preferenceValue);
+      root.setAttribute("data-theme-resolved", theme);
+      root.style.colorScheme = theme;
+    },
+    []
+  );
+
+  useEffect(() => {
+    applyTheme(preference);
+
+    if (preference !== "auto") {
+      return;
+    }
+
+    const interval = window.setInterval(() => {
+      applyTheme("auto");
+    }, 60 * 1000);
+
+    return () => window.clearInterval(interval);
+  }, [applyTheme, preference]);
+
+  const value = useMemo(
+    () => ({
+      preference,
+      resolvedTheme,
+      setPreference: (nextPreference: ThemePreference) => {
+        setPreference(nextPreference);
+        applyTheme(nextPreference);
+      },
+    }),
+    [applyTheme, preference, resolvedTheme]
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+
+  if (!context) {
+    throw new Error("useTheme debe usarse dentro de un ThemeProvider");
+  }
+
+  return context;
+}

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -9,7 +9,11 @@ body {
 }
 
 body {
-  background-color: theme("colors.gray.50");
+  @apply bg-gray-50 text-gray-900 transition-colors duration-300;
+}
+
+.dark body {
+  @apply bg-gray-950 text-gray-100;
 }
 
 ::selection {

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  darkMode: "class",
   content: [
     "./app/**/*.{js,ts,jsx,tsx}",
     "./components/**/*.{js,ts,jsx,tsx}"


### PR DESCRIPTION
## Summary
- add persistent theme preference with automatic day/night switching
- implement profile, password, and logout endpoints for authenticated users
- replace the settings page with name, password, theme, and session controls and wire up the ThemeProvider in the panel layout

## Testing
- npm run lint *(fails: Invalid project directory provided, no such directory: /workspace/agenda-inteligente/frontend/lint)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916b83ebc1883279b5189bc8baa135f)