### PR TITLE
Fix dark mode styling across panel views

### DIFF
--- a/frontend/app/(panel)/equipos/page.tsx
+++ b/frontend/app/(panel)/equipos/page.tsx
@@ -592,10 +592,10 @@ export default function EquiposPage() {
   );
 
   return (
-    <div className="space-y-10">
+    <div className="space-y-10 text-gray-900 dark:text-gray-100">
       <div className="flex flex-col gap-3">
-        <h1 className="text-3xl font-semibold text-gray-900">Equipos</h1>
-        <p className="text-sm text-gray-600">
+        <h1 className="text-3xl font-semibold text-gray-900 dark:text-gray-100">Equipos</h1>
+        <p className="text-sm text-gray-600 dark:text-gray-300">
           Organiza tu trabajo colaborativo: revisa tus equipos activos, responde
           invitaciones pendientes y crea nuevos grupos para tus proyectos.
         </p>
@@ -605,28 +605,28 @@ export default function EquiposPage() {
         <div
           className={`rounded-md border px-4 py-3 text-sm font-medium ${
             feedback.type === "success"
-              ? "border-green-200 bg-green-50 text-green-700"
-              : "border-red-200 bg-red-50 text-red-700"
+              ? "border-green-200 bg-green-50 text-green-700 dark:border-green-500/40 dark:bg-green-500/10 dark:text-green-200"
+              : "border-red-200 bg-red-50 text-red-700 dark:border-red-500/40 dark:bg-red-500/10 dark:text-red-200"
           }`}
         >
           {feedback.message}
         </div>
       )}
 
-      <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+      <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
         <div className="flex items-center justify-between">
-          <h2 className="text-xl font-semibold text-gray-900">Mis equipos</h2>
-          {cargando && <span className="text-xs text-gray-500">Actualizando…</span>}
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Mis equipos</h2>
+          {cargando && <span className="text-xs text-gray-500 dark:text-gray-400">Actualizando…</span>}
         </div>
         {!equipos.length && !cargando ? (
-          <p className="mt-6 text-sm text-gray-500">
+          <p className="mt-6 text-sm text-gray-500 dark:text-gray-400">
             Todavía no formas parte de ningún equipo. ¡Crea uno nuevo o acepta
             una invitación!
           </p>
         ) : (
           <div className="mt-6 overflow-x-auto">
-            <table className="min-w-full divide-y divide-gray-200 text-left text-sm">
-              <thead className="bg-gray-50 text-xs uppercase tracking-wide text-gray-500">
+            <table className="min-w-full divide-y divide-gray-200 text-left text-sm dark:divide-gray-800">
+              <thead className="bg-gray-50 text-xs uppercase tracking-wide text-gray-500 dark:bg-gray-900 dark:text-gray-300">
                 <tr>
                   <th className="px-4 py-3">Nombre</th>
                   <th className="px-4 py-3">Creado por</th>
@@ -635,28 +635,28 @@ export default function EquiposPage() {
                   <th className="px-4 py-3 text-right">Acciones</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-gray-100">
+              <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
                 {equipos.map((equipo) => {
                   const esAdministrador = equipo.rol === "administrador";
                   return (
-                    <tr key={equipo.id} className="hover:bg-gray-50">
-                      <td className="px-4 py-3 font-medium text-gray-900">
+                    <tr key={equipo.id} className="transition hover:bg-gray-50 dark:hover:bg-gray-800/70">
+                      <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">
                         <div className="flex items-center gap-2">
                           <span>{equipo.nombre}</span>
                           {esAdministrador && (
-                            <span className="rounded-full bg-indigo-100 px-2 py-0.5 text-xs font-semibold text-indigo-700">
+                            <span className="rounded-full bg-indigo-100 px-2 py-0.5 text-xs font-semibold text-indigo-700 dark:bg-indigo-500/20 dark:text-indigo-200">
                               Administras
                             </span>
                           )}
                         </div>
                       </td>
-                      <td className="px-4 py-3 text-gray-600">
+                      <td className="px-4 py-3 text-gray-600 dark:text-gray-300">
                         {equipo.creador_nombre ?? "Desconocido"}
                       </td>
-                      <td className="px-4 py-3 text-gray-600">
+                      <td className="px-4 py-3 text-gray-600 dark:text-gray-300">
                         {formatearFecha(equipo.creado_en)}
                       </td>
-                      <td className="px-4 py-3 text-center text-gray-600">
+                      <td className="px-4 py-3 text-center text-gray-600 dark:text-gray-300">
                         {equipo.miembros}
                       </td>
                       <td className="px-4 py-3">
@@ -664,14 +664,14 @@ export default function EquiposPage() {
                           <div className="flex justify-end gap-2">
                             <button
                               onClick={() => abrirModalEdicion(equipo.id)}
-                              className="rounded-md border border-gray-300 px-3 py-1.5 text-xs font-semibold text-gray-700 transition hover:bg-gray-50"
+                              className="rounded-md border border-gray-300 px-3 py-1.5 text-xs font-semibold text-gray-700 transition hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800/80"
                             >
                               Editar
                             </button>
                             <button
                               onClick={() => manejarEliminarEquipo(equipo.id)}
                               disabled={estaProcesando(`eliminar-equipo-${equipo.id}`)}
-                              className={`rounded-md bg-red-600 px-3 py-1.5 text-xs font-semibold text-white transition hover:bg-red-700 disabled:cursor-not-allowed disabled:bg-red-400`}
+                              className={`rounded-md bg-red-600 px-3 py-1.5 text-xs font-semibold text-white transition hover:bg-red-700 disabled:cursor-not-allowed disabled:bg-red-400 dark:bg-red-500 dark:hover:bg-red-400`}
                             >
                               {estaProcesando(`eliminar-equipo-${equipo.id}`)
                                 ? "Eliminando…"
@@ -683,7 +683,7 @@ export default function EquiposPage() {
                             <button
                               onClick={() => manejarAbandonarEquipo(equipo.id)}
                               disabled={estaProcesando(`abandonar-${equipo.id}`)}
-                              className="rounded-md border border-red-200 px-3 py-1.5 text-xs font-semibold text-red-600 transition hover:bg-red-50 disabled:cursor-not-allowed disabled:border-red-100 disabled:text-red-300"
+                              className="rounded-md border border-red-200 px-3 py-1.5 text-xs font-semibold text-red-600 transition hover:bg-red-50 disabled:cursor-not-allowed disabled:border-red-100 disabled:text-red-300 dark:border-red-500/40 dark:text-red-300 dark:hover:bg-red-500/10"
                             >
                               {estaProcesando(`abandonar-${equipo.id}`)
                                 ? "Saliendo…"
@@ -701,13 +701,13 @@ export default function EquiposPage() {
         )}
       </section>
 
-      <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+      <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
         <div className="flex items-center justify-between">
-          <h2 className="text-xl font-semibold text-gray-900">Invitaciones pendientes</h2>
-          {cargando && <span className="text-xs text-gray-500">Actualizando…</span>}
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Invitaciones pendientes</h2>
+          {cargando && <span className="text-xs text-gray-500 dark:text-gray-400">Actualizando…</span>}
         </div>
         {!invitaciones.length && !cargando ? (
-          <p className="mt-6 text-sm text-gray-500">
+          <p className="mt-6 text-sm text-gray-500 dark:text-gray-400">
             No tienes invitaciones por el momento.
           </p>
         ) : (
@@ -715,13 +715,13 @@ export default function EquiposPage() {
             {invitaciones.map((invitacion) => (
               <li
                 key={invitacion.id}
-                className="flex flex-col gap-3 rounded-lg border border-gray-100 bg-gray-50 p-4 sm:flex-row sm:items-center sm:justify-between"
+                className="flex flex-col gap-3 rounded-lg border border-gray-100 bg-gray-50 p-4 transition-colors dark:border-gray-700 dark:bg-gray-900/80 sm:flex-row sm:items-center sm:justify-between"
               >
                 <div>
-                  <p className="text-sm font-semibold text-gray-900">
+                  <p className="text-sm font-semibold text-gray-900 dark:text-gray-100">
                     {invitacion.equipo_nombre}
                   </p>
-                  <p className="text-xs text-gray-600">
+                  <p className="text-xs text-gray-600 dark:text-gray-300">
                     Invitado por {invitacion.invitado_por_nombre ?? "alguien"} el {" "}
                     {formatearFecha(invitacion.invitado_en)}
                   </p>
@@ -730,14 +730,14 @@ export default function EquiposPage() {
                   <button
                     onClick={() => manejarRespuestaInvitacion(invitacion.id, "aceptar")}
                     disabled={procesandoInvitacion === invitacion.id}
-                    className="rounded-md bg-green-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-green-700 disabled:cursor-not-allowed disabled:bg-green-400"
+                    className="rounded-md bg-green-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-green-700 disabled:cursor-not-allowed disabled:bg-green-400 dark:bg-green-500 dark:hover:bg-green-400"
                   >
                     Aceptar
                   </button>
                   <button
                     onClick={() => manejarRespuestaInvitacion(invitacion.id, "rechazar")}
                     disabled={procesandoInvitacion === invitacion.id}
-                    className="rounded-md bg-red-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-red-700 disabled:cursor-not-allowed disabled:bg-red-400"
+                    className="rounded-md bg-red-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-red-700 disabled:cursor-not-allowed disabled:bg-red-400 dark:bg-red-500 dark:hover:bg-red-400"
                   >
                     Rechazar
                   </button>
@@ -748,11 +748,11 @@ export default function EquiposPage() {
         )}
       </section>
 
-      <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
-        <h2 className="text-xl font-semibold text-gray-900">Crear equipo</h2>
+      <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Crear equipo</h2>
         <form onSubmit={manejarCreacionEquipo} className="mt-6 space-y-6">
           <div className="space-y-2">
-            <label htmlFor="nombre" className="block text-sm font-medium text-gray-700">
+            <label htmlFor="nombre" className="block text-sm font-medium text-gray-700 dark:text-gray-200">
               Nombre del equipo
             </label>
             <input
@@ -762,15 +762,15 @@ export default function EquiposPage() {
               value={nombreEquipo}
               onChange={(event) => setNombreEquipo(event.target.value)}
               placeholder="Ej. Equipo de producto"
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 shadow-sm transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-gray-700 dark:bg-gray-900/70 dark:text-gray-100"
             />
           </div>
 
           <div className="space-y-2">
-            <label htmlFor="invitados" className="block text-sm font-medium text-gray-700">
+            <label htmlFor="invitados" className="block text-sm font-medium text-gray-700 dark:text-gray-200">
               Invitar usuarios
             </label>
-            <p className="text-xs text-gray-500">
+            <p className="text-xs text-gray-500 dark:text-gray-400">
               Selecciona uno o varios compañeros para enviarles una invitación.
             </p>
             <select
@@ -783,7 +783,7 @@ export default function EquiposPage() {
                 );
                 setInvitadosSeleccionados(opciones);
               }}
-              className="h-40 w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+              className="h-40 w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 shadow-sm transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-gray-700 dark:bg-gray-900/70 dark:text-gray-100"
             >
               {usuarios.length === 0 ? (
                 <option disabled value="">
@@ -803,14 +803,14 @@ export default function EquiposPage() {
             <button
               type="button"
               onClick={resetFormulario}
-              className="rounded-md border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-700 transition hover:bg-gray-50"
+              className="rounded-md border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-700 transition hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800/80"
             >
               Limpiar
             </button>
             <button
               type="submit"
               disabled={creando}
-              className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-indigo-700 disabled:cursor-not-allowed disabled:bg-indigo-400"
+              className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-indigo-700 disabled:cursor-not-allowed disabled:bg-indigo-400 dark:bg-indigo-500 dark:hover:bg-indigo-400"
             >
               {creando ? "Creando…" : "Crear equipo"}
             </button>
@@ -820,12 +820,12 @@ export default function EquiposPage() {
 
       {modalEdicionAbierta && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4 py-6">
-          <div className="w-full max-w-2xl rounded-xl bg-white p-6 shadow-xl">
+          <div className="w-full max-w-2xl rounded-xl bg-white p-6 shadow-xl dark:bg-gray-950">
             <div className="flex items-start justify-between gap-4">
               <div>
-                <h3 className="text-lg font-semibold text-gray-900">Editar equipo</h3>
+                <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Editar equipo</h3>
                 {equipoEditando && (
-                  <p className="text-sm text-gray-500">
+                  <p className="text-sm text-gray-500 dark:text-gray-400">
                     Gestiona el nombre y los miembros del equipo.
                   </p>
                 )}
@@ -833,18 +833,18 @@ export default function EquiposPage() {
               <button
                 type="button"
                 onClick={cerrarModalEdicion}
-                className="rounded-md border border-gray-300 px-3 py-1.5 text-xs font-semibold text-gray-600 transition hover:bg-gray-50"
+                className="rounded-md border border-gray-300 px-3 py-1.5 text-xs font-semibold text-gray-600 transition hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800/80"
               >
                 Cerrar
               </button>
             </div>
 
             {cargandoDetalle || !equipoEditando ? (
-              <div className="py-12 text-center text-sm text-gray-500">Cargando información…</div>
+              <div className="py-12 text-center text-sm text-gray-500 dark:text-gray-400">Cargando información…</div>
             ) : (
               <div className="mt-6 space-y-6">
                 <form onSubmit={manejarEdicionNombre} className="space-y-2">
-                  <label htmlFor="nombre-edicion" className="block text-sm font-medium text-gray-700">
+                  <label htmlFor="nombre-edicion" className="block text-sm font-medium text-gray-700 dark:text-gray-200">
                     Nombre del equipo
                   </label>
                   <input
@@ -852,13 +852,13 @@ export default function EquiposPage() {
                     type="text"
                     value={nuevoNombreEquipo}
                     onChange={(event) => setNuevoNombreEquipo(event.target.value)}
-                    className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                    className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 shadow-sm transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-gray-700 dark:bg-gray-900/70 dark:text-gray-100"
                   />
                   <div className="flex justify-end">
                     <button
                       type="submit"
                       disabled={estaProcesando(`renombrar-${equipoEditando.id}`)}
-                      className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-indigo-700 disabled:cursor-not-allowed disabled:bg-indigo-400"
+                      className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-indigo-700 disabled:cursor-not-allowed disabled:bg-indigo-400 dark:bg-indigo-500 dark:hover:bg-indigo-400"
                     >
                       {estaProcesando(`renombrar-${equipoEditando.id}`)
                         ? "Guardando…"
@@ -870,8 +870,8 @@ export default function EquiposPage() {
                 <div className="space-y-3">
                   <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
                     <div>
-                      <h4 className="text-sm font-semibold text-gray-900">Miembros del equipo</h4>
-                      <p className="text-xs text-gray-500">
+                      <h4 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Miembros del equipo</h4>
+                      <p className="text-xs text-gray-500 dark:text-gray-400">
                         Administra las invitaciones y la composición del equipo.
                       </p>
                     </div>
@@ -879,7 +879,7 @@ export default function EquiposPage() {
                       <select
                         value={invitadoAAgregar}
                         onChange={(event) => setInvitadoAAgregar(event.target.value)}
-                        className="min-w-[220px] rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                        className="min-w-[220px] rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 shadow-sm transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-gray-700 dark:bg-gray-900/70 dark:text-gray-100"
                       >
                         <option value="" disabled>
                           {usuariosDisponibles.length
@@ -898,7 +898,7 @@ export default function EquiposPage() {
                         disabled={
                           !invitadoAAgregar || estaProcesando(`invitar-${equipoEditando.id}`)
                         }
-                        className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-indigo-700 disabled:cursor-not-allowed disabled:bg-indigo-400"
+                        className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-indigo-700 disabled:cursor-not-allowed disabled:bg-indigo-400 dark:bg-indigo-500 dark:hover:bg-indigo-400"
                       >
                         {estaProcesando(`invitar-${equipoEditando.id}`)
                           ? "Enviando…"
@@ -909,25 +909,25 @@ export default function EquiposPage() {
 
                   <div className="max-h-64 space-y-3 overflow-y-auto pr-2">
                     {equipoEditando.miembros.length === 0 ? (
-                      <p className="text-sm text-gray-500">
+                      <p className="text-sm text-gray-500 dark:text-gray-400">
                         Aún no hay miembros en este equipo.
                       </p>
                     ) : (
                       equipoEditando.miembros.map((miembro) => (
                         <div
                           key={miembro.id}
-                          className="flex flex-col gap-2 rounded-lg border border-gray-100 bg-gray-50 p-4 sm:flex-row sm:items-center sm:justify-between"
+                          className="flex flex-col gap-2 rounded-lg border border-gray-100 bg-gray-50 p-4 transition-colors dark:border-gray-700 dark:bg-gray-900/70 sm:flex-row sm:items-center sm:justify-between"
                         >
                           <div>
-                            <p className="text-sm font-semibold text-gray-900">{miembro.nombre}</p>
-                            <p className="text-xs text-gray-600">{miembro.correo}</p>
+                            <p className="text-sm font-semibold text-gray-900 dark:text-gray-100">{miembro.nombre}</p>
+                            <p className="text-xs text-gray-600 dark:text-gray-300">{miembro.correo}</p>
                           </div>
                           <div className="flex items-center gap-2">
                             <span
                               className={`rounded-full px-2 py-0.5 text-xs font-semibold ${
                                 miembro.rol === "administrador"
-                                  ? "bg-indigo-100 text-indigo-700"
-                                  : "bg-blue-100 text-blue-700"
+                                  ? "bg-indigo-100 text-indigo-700 dark:bg-indigo-500/20 dark:text-indigo-200"
+                                  : "bg-blue-100 text-blue-700 dark:bg-blue-500/20 dark:text-blue-200"
                               }`}
                             >
                               {miembro.rol === "administrador" ? "Administrador" : "Miembro"}
@@ -935,10 +935,10 @@ export default function EquiposPage() {
                             <span
                               className={`rounded-full px-2 py-0.5 text-xs font-medium ${
                                 miembro.estado === "aceptado"
-                                  ? "bg-green-100 text-green-700"
+                                  ? "bg-green-100 text-green-700 dark:bg-green-500/20 dark:text-green-200"
                                   : miembro.estado === "pendiente"
-                                  ? "bg-yellow-100 text-yellow-800"
-                                  : "bg-red-100 text-red-700"
+                                  ? "bg-yellow-100 text-yellow-800 dark:bg-amber-500/20 dark:text-amber-200"
+                                  : "bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-200"
                               }`}
                             >
                               {miembro.estado === "aceptado"
@@ -952,7 +952,7 @@ export default function EquiposPage() {
                                 type="button"
                                 onClick={() => manejarEliminarMiembro(miembro)}
                                 disabled={estaProcesando(`eliminar-miembro-${miembro.id}`)}
-                                className="rounded-md border border-red-200 px-3 py-1 text-xs font-semibold text-red-600 transition hover:bg-red-50 disabled:cursor-not-allowed disabled:border-red-100 disabled:text-red-300"
+                                className="rounded-md border border-red-200 px-3 py-1 text-xs font-semibold text-red-600 transition hover:bg-red-50 disabled:cursor-not-allowed disabled:border-red-100 disabled:text-red-300 dark:border-red-500/40 dark:text-red-300 dark:hover:bg-red-500/10"
                               >
                                 {estaProcesando(`eliminar-miembro-${miembro.id}`)
                                   ? "Quitando…"
@@ -966,20 +966,20 @@ export default function EquiposPage() {
                   </div>
                 </div>
 
-                <div className="flex flex-col gap-3 border-t border-gray-100 pt-4 sm:flex-row sm:items-center sm:justify-between">
+                <div className="flex flex-col gap-3 border-t border-gray-100 pt-4 sm:flex-row sm:items-center sm:justify-between dark:border-gray-800">
                   <button
                     type="button"
                     onClick={() => equipoEditando && manejarEliminarEquipo(equipoEditando.id)}
                     disabled={
                       !equipoEditando || estaProcesando(`eliminar-equipo-${equipoEditando?.id}`)
                     }
-                    className="rounded-md bg-red-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-red-700 disabled:cursor-not-allowed disabled:bg-red-400"
+                    className="rounded-md bg-red-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-red-700 disabled:cursor-not-allowed disabled:bg-red-400 dark:bg-red-500 dark:hover:bg-red-400"
                   >
                     {estaProcesando(`eliminar-equipo-${equipoEditando.id}`)
                       ? "Eliminando…"
                       : "Eliminar equipo"}
                   </button>
-                  <p className="text-xs text-gray-500">
+                  <p className="text-xs text-gray-500 dark:text-gray-400">
                     Solo el administrador puede eliminar el equipo o a sus miembros.
                   </p>
                 </div>

--- a/frontend/app/(panel)/eventos/page.tsx
+++ b/frontend/app/(panel)/eventos/page.tsx
@@ -254,16 +254,16 @@ const CalendarioUnificadoPage = () => {
 
   return (
     <>
-      <div className="flex flex-1 flex-col gap-6">
+      <div className="flex flex-1 flex-col gap-6 text-gray-900 dark:text-gray-100">
       <div className="flex flex-col gap-2">
-        <h1 className="text-3xl font-bold text-gray-900">Calendario unificado de eventos y tareas</h1>
-        <p className="text-gray-600">
+        <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">Calendario unificado de eventos y tareas</h1>
+        <p className="text-gray-600 dark:text-gray-300">
           Consulta de un vistazo tus eventos, tareas personales y tareas grupales en un mismo calendario.
         </p>
         <div className="mt-2 flex flex-wrap items-center justify-between gap-3">
           <div className="flex flex-wrap items-center gap-4">
             {legendItems.map((legend) => (
-              <div key={legend.label} className="flex items-center gap-2 text-sm text-gray-600">
+              <div key={legend.label} className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300">
                 <span
                   className="inline-flex h-3 w-3 rounded-full"
                   style={{ backgroundColor: legend.color }}
@@ -275,7 +275,7 @@ const CalendarioUnificadoPage = () => {
           </div>
           <button
             type="button"
-            className="inline-flex items-center rounded-xl bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-500"
+            className="inline-flex items-center rounded-xl bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-500 dark:bg-blue-500 dark:hover:bg-blue-400"
             onClick={abrirModalCrear}
           >
             Crear evento
@@ -287,8 +287,8 @@ const CalendarioUnificadoPage = () => {
         <div
           className={`rounded-lg border px-4 py-2 text-sm ${
             mensaje.tipo === "success"
-              ? "border-green-200 bg-green-50 text-green-700"
-              : "border-red-200 bg-red-50 text-red-700"
+              ? "border-green-200 bg-green-50 text-green-700 dark:border-green-500/40 dark:bg-green-500/10 dark:text-green-200"
+              : "border-red-200 bg-red-50 text-red-700 dark:border-red-500/40 dark:bg-red-500/10 dark:text-red-200"
           }`}
         >
           {mensaje.texto}
@@ -296,20 +296,20 @@ const CalendarioUnificadoPage = () => {
       )}
 
       {error && (
-        <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+        <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-500/40 dark:bg-red-500/10 dark:text-red-200">
           {error instanceof Error ? error.message : "No se pudo cargar el calendario"}
         </div>
       )}
 
       <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
-        <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
-          <div className="border-b border-gray-100 bg-gray-50 px-6 py-4">
-            <h2 className="text-lg font-semibold text-gray-900">Tu calendario</h2>
-            <p className="text-sm text-gray-500">Navega entre meses y crea hábitos alrededor de tus compromisos.</p>
+        <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900">
+          <div className="border-b border-gray-100 bg-gray-50 px-6 py-4 dark:border-gray-800 dark:bg-gray-900/70">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Tu calendario</h2>
+            <p className="text-sm text-gray-500 dark:text-gray-400">Navega entre meses y crea hábitos alrededor de tus compromisos.</p>
           </div>
           <div className="p-4">
             {isLoading && eventosCalendario.length === 0 ? (
-              <div className="flex min-h-[480px] items-center justify-center text-sm text-gray-500">
+              <div className="flex min-h-[480px] items-center justify-center text-sm text-gray-500 dark:text-gray-400">
                 Cargando calendario...
               </div>
             ) : (
@@ -328,14 +328,14 @@ const CalendarioUnificadoPage = () => {
         </div>
 
         <aside className="flex h-full flex-col gap-4">
-          <div className="rounded-2xl border border-gray-200 bg-white shadow-sm">
-            <div className="border-b border-gray-100 px-5 py-4">
-              <h3 className="text-lg font-semibold text-gray-900">Próximos compromisos</h3>
-              <p className="text-sm text-gray-500">Los siguientes eventos y tareas en tu agenda.</p>
+          <div className="rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900">
+            <div className="border-b border-gray-100 px-5 py-4 dark:border-gray-800 dark:bg-gray-900/70">
+              <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Próximos compromisos</h3>
+              <p className="text-sm text-gray-500 dark:text-gray-400">Los siguientes eventos y tareas en tu agenda.</p>
             </div>
             <div className="flex flex-col gap-4 px-5 py-4">
               {proximosEventos.length === 0 ? (
-                <p className="text-sm text-gray-500">No hay eventos o tareas próximos.</p>
+                <p className="text-sm text-gray-500 dark:text-gray-400">No hay eventos o tareas próximos.</p>
               ) : (
                 proximosEventos.map(({ item }) => {
                   const color = obtenerColorPorTipo(item.tipo);
@@ -352,12 +352,12 @@ const CalendarioUnificadoPage = () => {
                     item.estado_asistencia === "pendiente";
 
                   return (
-                    <div key={item.id} className="rounded-xl border border-gray-100 bg-white p-4 shadow-sm">
+                    <div key={item.id} className="rounded-xl border border-gray-100 bg-white p-4 shadow-sm transition-colors dark:border-gray-700 dark:bg-gray-900/80">
                       <div className="flex items-start justify-between gap-3">
                         <div className="flex flex-col gap-1">
                           <div className="flex items-center gap-2">
                             <span className="inline-flex h-2.5 w-2.5 rounded-full" style={{ backgroundColor: color }} />
-                            <span className="text-xs font-medium uppercase text-gray-500">
+                            <span className="text-xs font-medium uppercase text-gray-500 dark:text-gray-400">
                               {item.tipo === "evento"
                                 ? "Evento"
                                 : item.tipo === "tarea_grupal"
@@ -365,15 +365,15 @@ const CalendarioUnificadoPage = () => {
                                   : "Tarea personal"}
                             </span>
                           </div>
-                          <p className="text-base font-semibold text-gray-900">
+                          <p className="text-base font-semibold text-gray-900 dark:text-gray-100">
                             {item.tipo === "tarea_grupal" ? `👥 ${item.titulo}` : item.titulo}
                           </p>
-                          <p className="text-sm text-gray-600">{fechaTexto}</p>
+                          <p className="text-sm text-gray-600 dark:text-gray-300">{fechaTexto}</p>
                           {item.tipo === "evento" && item.equipo_nombre && (
-                            <p className="text-xs text-gray-500">Equipo: {item.equipo_nombre}</p>
+                            <p className="text-xs text-gray-500 dark:text-gray-400">Equipo: {item.equipo_nombre}</p>
                           )}
                           {descripcionCorta && (
-                            <p className="text-xs text-gray-500">{descripcionCorta}</p>
+                            <p className="text-xs text-gray-500 dark:text-gray-400">{descripcionCorta}</p>
                           )}
                         </div>
                       </div>
@@ -381,7 +381,7 @@ const CalendarioUnificadoPage = () => {
                         <div className="mt-3 flex flex-wrap items-center gap-2">
                           <button
                             type="button"
-                            className="rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-blue-300"
+                            className="rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-blue-300 dark:bg-blue-500 dark:hover:bg-blue-400"
                             onClick={() => manejarRespuesta(item, "aceptado")}
                             disabled={respuestaPendiente !== null}
                           >
@@ -389,7 +389,7 @@ const CalendarioUnificadoPage = () => {
                           </button>
                           <button
                             type="button"
-                            className="rounded-lg border border-gray-300 px-3 py-1.5 text-xs font-semibold text-gray-700 transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
+                            className="rounded-lg border border-gray-300 px-3 py-1.5 text-xs font-semibold text-gray-700 transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800/70"
                             onClick={() => manejarRespuesta(item, "rechazado")}
                             disabled={respuestaPendiente !== null}
                           >
@@ -398,7 +398,7 @@ const CalendarioUnificadoPage = () => {
                         </div>
                       )}
                       {item.tipo === "evento" && item.estado_asistencia && item.estado_asistencia !== "pendiente" && (
-                        <p className="mt-3 text-xs font-medium text-gray-500">
+                        <p className="mt-3 text-xs font-medium text-gray-500 dark:text-gray-400">
                           Tu estado: {item.estado_asistencia === "aceptado" ? "✅ Aceptado" : "❌ Rechazado"}
                         </p>
                       )}
@@ -409,9 +409,9 @@ const CalendarioUnificadoPage = () => {
             </div>
           </div>
 
-          <div className="rounded-2xl border border-dashed border-gray-300 bg-gray-50 p-5 text-sm text-gray-600">
-            <p className="font-semibold text-gray-800">Consejo</p>
-            <p className="mt-1">
+          <div className="rounded-2xl border border-dashed border-gray-300 bg-gray-50 p-5 text-sm text-gray-600 dark:border-gray-600 dark:bg-gray-900/70 dark:text-gray-300">
+            <p className="font-semibold text-gray-800 dark:text-gray-100">Consejo</p>
+            <p className="mt-1 text-gray-600 dark:text-gray-300">
               Arrastra eventos directamente en el calendario para reorganizar tu semana una vez que esta funcionalidad esté disponible.
             </p>
           </div>

--- a/frontend/app/(panel)/inicio/page.tsx
+++ b/frontend/app/(panel)/inicio/page.tsx
@@ -217,14 +217,23 @@ function obtenerTimestamp(item: ItemHoy): number {
 
 function obtenerEtiquetaTipo(item: ItemHoy): { texto: string; clases: string } {
   if (item.tipo === "evento") {
-    return { texto: "Evento", clases: "bg-blue-100 text-blue-700" };
+    return {
+      texto: "Evento",
+      clases: "bg-blue-100 text-blue-700 dark:bg-blue-500/20 dark:text-blue-200",
+    };
   }
 
   if (item.tipo === "tarea_grupal") {
-    return { texto: "Tarea grupal", clases: "bg-purple-100 text-purple-700" };
+    return {
+      texto: "Tarea grupal",
+      clases: "bg-purple-100 text-purple-700 dark:bg-purple-500/20 dark:text-purple-200",
+    };
   }
 
-  return { texto: "Tarea personal", clases: "bg-emerald-100 text-emerald-700" };
+  return {
+    texto: "Tarea personal",
+    clases: "bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-200",
+  };
 }
 
 function obtenerEtiquetaEstado(notificacion: Notificacion): { texto: string; clases: string } | null {
@@ -233,14 +242,23 @@ function obtenerEtiquetaEstado(notificacion: Notificacion): { texto: string; cla
   }
 
   if (notificacion.estado === "aceptado") {
-    return { texto: "Aceptado", clases: "bg-emerald-100 text-emerald-700" };
+    return {
+      texto: "Aceptado",
+      clases: "bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-200",
+    };
   }
 
   if (notificacion.estado === "rechazado") {
-    return { texto: "Rechazado", clases: "bg-rose-100 text-rose-700" };
+    return {
+      texto: "Rechazado",
+      clases: "bg-rose-100 text-rose-700 dark:bg-rose-500/20 dark:text-rose-200",
+    };
   }
 
-  return { texto: "Pendiente", clases: "bg-gray-100 text-gray-600" };
+  return {
+    texto: "Pendiente",
+    clases: "bg-gray-100 text-gray-600 dark:bg-gray-800/70 dark:text-gray-300",
+  };
 }
 
 function formatearTipoEvento(evento: Evento) {
@@ -756,10 +774,10 @@ export default function InicioPage() {
   );
 
   return (
-    <div className="flex flex-col gap-6 p-6">
-      <header>
-        <h1 className="text-3xl font-semibold mb-1">Hola, {nombreUsuario} 👋</h1>
-        <p className="text-gray-600">
+    <div className="flex flex-col gap-6 p-6 text-gray-900 dark:text-gray-100">
+      <header className="space-y-1">
+        <h1 className="mb-1 text-3xl font-semibold">Hola, {nombreUsuario} 👋</h1>
+        <p className="text-gray-600 dark:text-gray-300">
           Hoy es {fechaResumen}. Tienes {" "}
           <span className="font-medium">{totalTareasHoy}</span> tareas y {" "}
           <span className="font-medium">{totalEventosHoy}</span> eventos para hoy.
@@ -768,17 +786,19 @@ export default function InicioPage() {
 
       <div className="grid gap-6 lg:grid-cols-[2fr_1fr]">
         <div className="space-y-6">
-          <section className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+          <section className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
             <div className="flex items-center justify-between">
-              <h2 className="text-xl font-semibold">Hoy</h2>
-              {cargandoDashboard && <span className="text-sm text-gray-400">Actualizando...</span>}
+              <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Hoy</h2>
+              {cargandoDashboard && (
+                <span className="text-sm text-gray-400 dark:text-gray-500">Actualizando...</span>
+              )}
             </div>
             {errorDashboard && (
-              <p className="mt-2 text-sm text-rose-600">{errorDashboard}</p>
+              <p className="mt-2 text-sm text-rose-600 dark:text-rose-300">{errorDashboard}</p>
             )}
 
             {!cargandoDashboard && itemsHoy.length === 0 ? (
-              <div className="mt-6 rounded-xl border border-dashed border-gray-300 bg-gray-50 px-6 py-10 text-center text-gray-600">
+              <div className="mt-6 rounded-xl border border-dashed border-gray-300 bg-gray-50 px-6 py-10 text-center text-gray-600 dark:border-gray-700 dark:bg-gray-800/80 dark:text-gray-300">
                 No tienes eventos ni tareas para hoy 🎉
               </div>
             ) : (
@@ -788,7 +808,7 @@ export default function InicioPage() {
                   return (
                     <li
                       key={item.id}
-                      className="flex flex-col gap-3 rounded-xl border border-gray-200 bg-white p-4 shadow-sm md:flex-row md:items-center md:justify-between"
+                      className="flex flex-col gap-3 rounded-xl border border-gray-200 bg-white p-4 shadow-sm transition-colors dark:border-gray-700 dark:bg-gray-900 md:flex-row md:items-center md:justify-between"
                     >
                       <div className="flex flex-1 flex-col gap-2">
                         <div className="flex flex-wrap items-center gap-2">
@@ -796,23 +816,23 @@ export default function InicioPage() {
                             {etiqueta.texto}
                           </span>
                           {item.equipoNombre && (
-                            <span className="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-600">
+                            <span className="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-600 dark:bg-gray-800/70 dark:text-gray-300">
                               Equipo: {item.equipoNombre}
                             </span>
                           )}
                           {item.estadoInvitacion === "pendiente" && (
-                            <span className="inline-flex items-center rounded-full bg-amber-100 px-3 py-1 text-xs font-medium text-amber-700">
+                            <span className="inline-flex items-center rounded-full bg-amber-100 px-3 py-1 text-xs font-medium text-amber-700 dark:bg-amber-500/20 dark:text-amber-200">
                               Invitación pendiente
                             </span>
                           )}
                         </div>
-                        <p className="text-base font-semibold text-gray-900">{item.titulo}</p>
-                        <p className="text-sm text-gray-600">{formatearHoraItem(item)}</p>
+                        <p className="text-base font-semibold text-gray-900 dark:text-gray-100">{item.titulo}</p>
+                        <p className="text-sm text-gray-600 dark:text-gray-300">{formatearHoraItem(item)}</p>
                         {item.creadorNombre && (
-                          <p className="text-xs text-gray-500">Organiza: {item.creadorNombre}</p>
+                          <p className="text-xs text-gray-500 dark:text-gray-400">Organiza: {item.creadorNombre}</p>
                         )}
                         {item.descripcion && (
-                          <p className="text-sm text-gray-500">{item.descripcion}</p>
+                          <p className="text-sm text-gray-500 dark:text-gray-400">{item.descripcion}</p>
                         )}
                       </div>
                     </li>
@@ -822,15 +842,15 @@ export default function InicioPage() {
             )}
           </section>
 
-          <section className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+          <section className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
             <div className="flex items-center justify-between">
-              <h2 className="text-xl font-semibold">Calendario interno</h2>
-              <span className="text-sm text-gray-500">Eventos y tareas</span>
+              <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Calendario interno</h2>
+              <span className="text-sm text-gray-500 dark:text-gray-400">Eventos y tareas</span>
             </div>
 
             <div className="mt-4">
               {cargandoEventos ? (
-                <p className="text-gray-500">Cargando tus eventos...</p>
+                <p className="text-gray-500 dark:text-gray-400">Cargando tus eventos...</p>
               ) : (
                 <FullCalendar
                   plugins={plugins}
@@ -851,31 +871,31 @@ export default function InicioPage() {
         </div>
 
         <aside className="space-y-6">
-          <section className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+          <section className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
             <div className="mb-4 flex items-center justify-between gap-2">
-              <h2 className="text-xl font-semibold">Actividad reciente</h2>
+              <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Actividad reciente</h2>
               <button
                 type="button"
                 onClick={cargarNotificaciones}
-                className="rounded-lg border border-gray-200 px-3 py-1 text-sm font-medium text-gray-600 transition hover:border-gray-300 hover:bg-gray-50"
+                className="rounded-lg border border-gray-200 px-3 py-1 text-sm font-medium text-gray-600 transition hover:border-gray-300 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:border-gray-500 dark:hover:bg-gray-800/80"
               >
                 Actualizar
               </button>
             </div>
 
             {errorNotificaciones && (
-              <p className="mb-3 text-sm text-rose-600">{errorNotificaciones}</p>
+              <p className="mb-3 text-sm text-rose-600 dark:text-rose-300">{errorNotificaciones}</p>
             )}
 
             <div className="space-y-6">
               <div>
-                <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
                   Invitaciones pendientes
                 </h3>
                 {cargandoDashboard ? (
-                  <p className="mt-2 text-sm text-gray-500">Revisando invitaciones...</p>
+                  <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">Revisando invitaciones...</p>
                 ) : invitacionesPendientes.length === 0 ? (
-                  <p className="mt-2 text-sm text-gray-500">No tienes invitaciones pendientes.</p>
+                  <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">No tienes invitaciones pendientes.</p>
                 ) : (
                   <ul className="mt-3 space-y-3">
                     {invitacionesPendientes.map((invitacion) => {
@@ -886,18 +906,18 @@ export default function InicioPage() {
                       return (
                         <li
                           key={`invitacion-evento-${invitacion.eventoId}`}
-                          className="rounded-xl border border-amber-200 bg-amber-50/60 p-4 shadow-sm"
+                          className="rounded-xl border border-amber-200 bg-amber-50/60 p-4 shadow-sm dark:border-amber-500/40 dark:bg-amber-500/10"
                         >
                           <div className="flex flex-col gap-2">
-                            <p className="text-sm font-medium text-gray-900">
+                            <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
                               {creador} te invitó al evento “{invitacion.titulo}”
                             </p>
                             {invitacion.equipoNombre && (
-                              <span className="text-xs text-gray-600">
+                              <span className="text-xs text-gray-600 dark:text-gray-300">
                                 Equipo: {invitacion.equipoNombre}
                               </span>
                             )}
-                            <span className="text-xs text-gray-600">
+                            <span className="text-xs text-gray-600 dark:text-gray-300">
                               Cuando: {formatearRangoEvento(invitacion.inicio, invitacion.fin)}
                             </span>
                             <div className="mt-2 flex flex-wrap gap-2">
@@ -926,19 +946,19 @@ export default function InicioPage() {
                 )}
               </div>
 
-              <div className="space-y-4 border-t border-gray-200 pt-4">
+              <div className="space-y-4 border-t border-gray-200 pt-4 dark:border-gray-800">
                 <div className="flex items-center justify-between">
-                  <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                  <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
                     Actividad
                   </h3>
                   {cargandoNotificaciones && (
-                    <span className="text-xs text-gray-400">Actualizando...</span>
+                    <span className="text-xs text-gray-400 dark:text-gray-500">Actualizando...</span>
                   )}
                 </div>
                 {cargandoNotificaciones ? (
-                  <p className="text-sm text-gray-500">Cargando actividad...</p>
+                  <p className="text-sm text-gray-500 dark:text-gray-400">Cargando actividad...</p>
                 ) : notificacionesFiltradas.length === 0 ? (
-                  <p className="text-sm text-gray-500">No hay notificaciones recientes.</p>
+                  <p className="text-sm text-gray-500 dark:text-gray-400">No hay notificaciones recientes.</p>
                 ) : (
                   <ul className="space-y-4">
                     {notificacionesFiltradas.map((notificacion) => {
@@ -959,11 +979,11 @@ export default function InicioPage() {
                       return (
                         <li
                           key={notificacion.id}
-                          className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm"
+                          className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-900"
                         >
                           <div className="flex flex-col gap-2">
-                            <p className="text-sm font-medium text-gray-900">{notificacion.mensaje}</p>
-                            <span className="text-xs text-gray-500">
+                            <p className="text-sm font-medium text-gray-900 dark:text-gray-100">{notificacion.mensaje}</p>
+                            <span className="text-xs text-gray-500 dark:text-gray-400">
                               {formatearFechaNotificacion(notificacion.fecha)}
                             </span>
                             {etiquetaEstado && (
@@ -1013,43 +1033,43 @@ export default function InicioPage() {
           onClick={cerrarModalEvento}
         >
           <div
-            className={`w-full max-w-md transform rounded-2xl bg-white p-6 shadow-xl transition-all duration-300 ease-out ${
+            className={`w-full max-w-md transform rounded-2xl bg-white p-6 shadow-xl transition-all duration-300 ease-out dark:bg-gray-950 ${
               cerrandoModal ? "scale-95 opacity-0" : "scale-100 opacity-100"
             }`}
             onClick={(event) => event.stopPropagation()}
           >
             <div className="flex items-start justify-between gap-4">
               <div>
-                <h3 className="text-xl font-semibold text-gray-900">
+                <h3 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
                   {eventoSeleccionado.titulo ?? "(Sin título)"}
                 </h3>
-                <span className="mt-2 inline-flex items-center gap-1 rounded-full bg-blue-50 px-3 py-1 text-xs font-medium text-blue-600">
-                  <span className="h-2 w-2 rounded-full bg-blue-500" aria-hidden />
+                <span className="mt-2 inline-flex items-center gap-1 rounded-full bg-blue-50 px-3 py-1 text-xs font-medium text-blue-600 dark:bg-blue-500/20 dark:text-blue-200">
+                  <span className="h-2 w-2 rounded-full bg-blue-500 dark:bg-blue-400" aria-hidden />
                   {formatearTipoEvento(eventoSeleccionado)}
                 </span>
               </div>
             </div>
 
-            <div className="mt-6 space-y-4 text-sm text-gray-700">
-              <div className="rounded-lg border border-gray-100 bg-gray-50/70 p-4">
-                <p className="text-xs uppercase tracking-wide text-gray-500">Inicio</p>
-                <p className="mt-1 font-medium text-gray-900">{formatearFechaDetallada(eventoSeleccionado.inicio)}</p>
+            <div className="mt-6 space-y-4 text-sm text-gray-700 dark:text-gray-300">
+              <div className="rounded-lg border border-gray-100 bg-gray-50/70 p-4 dark:border-gray-700 dark:bg-gray-800/70">
+                <p className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Inicio</p>
+                <p className="mt-1 font-medium text-gray-900 dark:text-gray-100">{formatearFechaDetallada(eventoSeleccionado.inicio)}</p>
               </div>
-              <div className="rounded-lg border border-gray-100 bg-gray-50/70 p-4">
-                <p className="text-xs uppercase tracking-wide text-gray-500">Fin</p>
-                <p className="mt-1 font-medium text-gray-900">{formatearFechaDetallada(eventoSeleccionado.fin)}</p>
+              <div className="rounded-lg border border-gray-100 bg-gray-50/70 p-4 dark:border-gray-700 dark:bg-gray-800/70">
+                <p className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Fin</p>
+                <p className="mt-1 font-medium text-gray-900 dark:text-gray-100">{formatearFechaDetallada(eventoSeleccionado.fin)}</p>
               </div>
-              <div className="rounded-lg border border-gray-100 bg-white p-4">
-                <p className="text-xs uppercase tracking-wide text-gray-500">Ubicación</p>
-                <p className="mt-1 text-gray-900">
+              <div className="rounded-lg border border-gray-100 bg-white p-4 dark:border-gray-700 dark:bg-gray-900/80">
+                <p className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Ubicación</p>
+                <p className="mt-1 text-gray-900 dark:text-gray-100">
                   {eventoSeleccionado.ubicacion?.trim()
                     ? eventoSeleccionado.ubicacion
                     : "No se especificó una ubicación."}
                 </p>
               </div>
-              <div className="rounded-lg border border-gray-100 bg-white p-4">
-                <p className="text-xs uppercase tracking-wide text-gray-500">Descripción</p>
-                <p className="mt-1 whitespace-pre-line text-gray-900">
+              <div className="rounded-lg border border-gray-100 bg-white p-4 dark:border-gray-700 dark:bg-gray-900/80">
+                <p className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Descripción</p>
+                <p className="mt-1 whitespace-pre-line text-gray-900 dark:text-gray-100">
                   {eventoSeleccionado.descripcion?.trim()
                     ? eventoSeleccionado.descripcion
                     : "Sin descripción adicional."}
@@ -1061,7 +1081,7 @@ export default function InicioPage() {
               <button
                 type="button"
                 onClick={cerrarModalEvento}
-                className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700"
+                className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-400"
               >
                 Cerrar
               </button>

--- a/frontend/app/(panel)/layout.tsx
+++ b/frontend/app/(panel)/layout.tsx
@@ -18,7 +18,7 @@ export default async function PanelLayout({
 
   return (
     <ThemeProvider initialPreference={user?.tema_preferencia ?? "auto"}>
-      <div className="flex min-h-screen w-full bg-gray-50 transition-colors duration-300 dark:bg-gray-950">
+      <div className="flex min-h-screen w-full bg-gray-50 text-gray-900 transition-colors duration-300 dark:bg-gray-950 dark:text-gray-100">
         {/* Sidebar lateral */}
         <Sidebar />
 

--- a/frontend/components/CrearEventoModal.tsx
+++ b/frontend/components/CrearEventoModal.tsx
@@ -246,25 +246,25 @@ const CrearEventoModal = ({ open, onClose, onCreated, onError }: CrearEventoModa
   return (
     <div className="fixed inset-0 z-40 flex min-h-screen items-center justify-center bg-slate-900/50 px-4 py-6">
       <div className="absolute inset-0" onClick={onClose} aria-hidden="true" />
-      <div className="relative z-10 w-full max-w-2xl overflow-hidden rounded-3xl bg-white shadow-2xl">
-        <div className="flex items-center justify-between border-b border-gray-100 px-6 py-4">
+      <div className="relative z-10 w-full max-w-2xl overflow-hidden rounded-3xl bg-white shadow-2xl dark:bg-gray-950">
+        <div className="flex items-center justify-between border-b border-gray-100 px-6 py-4 dark:border-gray-800">
           <div>
-            <p className="text-sm font-semibold uppercase tracking-wide text-blue-600">Nuevo registro</p>
-            <h2 className="text-2xl font-bold text-gray-900">Crear evento o tarea</h2>
+            <p className="text-sm font-semibold uppercase tracking-wide text-blue-600 dark:text-blue-300">Nuevo registro</p>
+            <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Crear evento o tarea</h2>
           </div>
           <button
             type="button"
-            className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-gray-100 text-gray-600 transition hover:bg-gray-200"
+            className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-gray-100 text-gray-600 transition hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
             onClick={onClose}
             aria-label="Cerrar"
           >
             ×
           </button>
         </div>
-        <form onSubmit={manejarEnvio} className="space-y-6 px-6 py-6">
+        <form onSubmit={manejarEnvio} className="space-y-6 px-6 py-6 text-gray-900 dark:text-gray-100">
           <div className="grid gap-4 sm:grid-cols-2">
-            <div className="rounded-2xl border border-gray-200 p-4">
-              <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">Tipo</p>
+            <div className="rounded-2xl border border-gray-200 p-4 dark:border-gray-700 dark:bg-gray-900/70">
+              <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">Tipo</p>
               <div className="mt-3 flex gap-2">
                 {["evento", "tarea"].map((opcion) => (
                   <button
@@ -273,20 +273,20 @@ const CrearEventoModal = ({ open, onClose, onCreated, onError }: CrearEventoModa
                     onClick={() => manejarSeleccionTipo(opcion as TipoBase)}
                     className={`flex-1 rounded-xl border px-3 py-2 text-sm font-semibold transition ${
                       form.tipoBase === opcion
-                        ? "border-blue-600 bg-blue-50 text-blue-700"
-                        : "border-gray-200 text-gray-600 hover:border-gray-300"
+                        ? "border-blue-600 bg-blue-50 text-blue-700 dark:border-blue-400 dark:bg-blue-500/10 dark:text-blue-200"
+                        : "border-gray-200 text-gray-600 hover:border-gray-300 dark:border-gray-600 dark:text-gray-300 dark:hover:border-gray-500"
                     }`}
                   >
                     {opcion === "evento" ? "Evento" : "Tarea"}
                   </button>
                 ))}
               </div>
-              <p className="mt-2 text-xs text-gray-500">
+              <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
                 Los eventos se mostrarán con horario. Las tareas aparecerán como actividades de día completo.
               </p>
             </div>
-            <div className="rounded-2xl border border-gray-200 p-4">
-              <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">Alcance</p>
+            <div className="rounded-2xl border border-gray-200 p-4 dark:border-gray-700 dark:bg-gray-900/70">
+              <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">Alcance</p>
               <div className="mt-3 flex gap-2">
                 {["personal", "equipo"].map((opcion) => (
                   <button
@@ -295,22 +295,22 @@ const CrearEventoModal = ({ open, onClose, onCreated, onError }: CrearEventoModa
                     onClick={() => manejarSeleccionAlcance(opcion as Alcance)}
                     className={`flex-1 rounded-xl border px-3 py-2 text-sm font-semibold transition ${
                       form.alcance === opcion
-                        ? "border-blue-600 bg-blue-50 text-blue-700"
-                        : "border-gray-200 text-gray-600 hover:border-gray-300"
+                        ? "border-blue-600 bg-blue-50 text-blue-700 dark:border-blue-400 dark:bg-blue-500/10 dark:text-blue-200"
+                        : "border-gray-200 text-gray-600 hover:border-gray-300 dark:border-gray-600 dark:text-gray-300 dark:hover:border-gray-500"
                     }`}
                   >
                     {opcion === "personal" ? "Personal" : "Equipo"}
                   </button>
                 ))}
               </div>
-              <p className="mt-2 text-xs text-gray-500">
+              <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
                 Si eliges equipo, se registrará como tarea grupal automáticamente.
               </p>
             </div>
           </div>
 
           <div className="space-y-3">
-            <label className="block text-sm font-medium text-gray-700" htmlFor="titulo">
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="titulo">
               Título
             </label>
             <input
@@ -318,7 +318,7 @@ const CrearEventoModal = ({ open, onClose, onCreated, onError }: CrearEventoModa
               name="titulo"
               type="text"
               required
-              className="w-full rounded-2xl border border-gray-300 px-4 py-2 text-base text-gray-900 focus:border-blue-500 focus:outline-none"
+              className="w-full rounded-2xl border border-gray-300 px-4 py-2 text-base text-gray-900 transition focus:border-blue-500 focus:outline-none dark:border-gray-700 dark:bg-gray-900/70 dark:text-gray-100"
               placeholder="Ej. Plan de entrega del sprint"
               value={form.titulo}
               onChange={manejarCambio}
@@ -326,13 +326,13 @@ const CrearEventoModal = ({ open, onClose, onCreated, onError }: CrearEventoModa
           </div>
 
           <div className="space-y-3">
-            <label className="block text-sm font-medium text-gray-700" htmlFor="descripcion">
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="descripcion">
               Descripción
             </label>
             <textarea
               id="descripcion"
               name="descripcion"
-              className="w-full rounded-2xl border border-gray-300 px-4 py-2 text-sm text-gray-900 focus:border-blue-500 focus:outline-none"
+              className="w-full rounded-2xl border border-gray-300 px-4 py-2 text-sm text-gray-900 transition focus:border-blue-500 focus:outline-none dark:border-gray-700 dark:bg-gray-900/70 dark:text-gray-100"
               rows={4}
               placeholder="Agrega notas, objetivos o enlaces relevantes"
               value={form.descripcion}
@@ -341,15 +341,15 @@ const CrearEventoModal = ({ open, onClose, onCreated, onError }: CrearEventoModa
           </div>
 
           <div className="grid gap-4 md:grid-cols-2">
-            <div className="space-y-3 rounded-2xl border border-gray-200 p-4">
-              <p className="text-sm font-semibold text-gray-700">Inicio</p>
+            <div className="space-y-3 rounded-2xl border border-gray-200 p-4 dark:border-gray-700 dark:bg-gray-900/70">
+              <p className="text-sm font-semibold text-gray-700 dark:text-gray-200">Inicio</p>
               <div className="grid gap-3 sm:grid-cols-2">
                 <input
                   type="date"
                   name="fechaInicio"
                   value={form.fechaInicio}
                   onChange={manejarCambio}
-                  className="rounded-xl border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                  className="rounded-xl border border-gray-300 px-3 py-2 text-sm transition focus:border-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-900/70 dark:text-gray-100"
                   required
                 />
                 <input
@@ -357,20 +357,20 @@ const CrearEventoModal = ({ open, onClose, onCreated, onError }: CrearEventoModa
                   name="horaInicio"
                   value={form.horaInicio}
                   onChange={manejarCambio}
-                  className="rounded-xl border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                  className="rounded-xl border border-gray-300 px-3 py-2 text-sm transition focus:border-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-900/70 dark:text-gray-100"
                   required
                 />
               </div>
             </div>
-            <div className="space-y-3 rounded-2xl border border-gray-200 p-4">
-              <p className="text-sm font-semibold text-gray-700">Fin</p>
+            <div className="space-y-3 rounded-2xl border border-gray-200 p-4 dark:border-gray-700 dark:bg-gray-900/70">
+              <p className="text-sm font-semibold text-gray-700 dark:text-gray-200">Fin</p>
               <div className="grid gap-3 sm:grid-cols-2">
                 <input
                   type="date"
                   name="fechaFin"
                   value={form.fechaFin}
                   onChange={manejarCambio}
-                  className="rounded-xl border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                  className="rounded-xl border border-gray-300 px-3 py-2 text-sm transition focus:border-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-900/70 dark:text-gray-100"
                   required
                 />
                 <input
@@ -378,7 +378,7 @@ const CrearEventoModal = ({ open, onClose, onCreated, onError }: CrearEventoModa
                   name="horaFin"
                   value={form.horaFin}
                   onChange={manejarCambio}
-                  className="rounded-xl border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                  className="rounded-xl border border-gray-300 px-3 py-2 text-sm transition focus:border-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-900/70 dark:text-gray-100"
                   required
                 />
               </div>
@@ -387,7 +387,7 @@ const CrearEventoModal = ({ open, onClose, onCreated, onError }: CrearEventoModa
 
           {form.alcance === "equipo" && (
             <div className="space-y-3">
-              <label className="block text-sm font-medium text-gray-700" htmlFor="equipoId">
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="equipoId">
                 Equipo
               </label>
               <select
@@ -396,7 +396,7 @@ const CrearEventoModal = ({ open, onClose, onCreated, onError }: CrearEventoModa
                 value={form.equipoId}
                 onChange={manejarCambio}
                 required
-                className="w-full rounded-2xl border border-gray-300 px-4 py-2 text-sm text-gray-900 focus:border-blue-500 focus:outline-none"
+                className="w-full rounded-2xl border border-gray-300 px-4 py-2 text-sm text-gray-900 transition focus:border-blue-500 focus:outline-none dark:border-gray-700 dark:bg-gray-900/70 dark:text-gray-100"
               >
                 <option value="">Selecciona un equipo</option>
                 {equipos.map((equipo) => (
@@ -405,21 +405,21 @@ const CrearEventoModal = ({ open, onClose, onCreated, onError }: CrearEventoModa
                   </option>
                 ))}
               </select>
-              {cargandoEquipos && <p className="text-xs text-gray-500">Cargando equipos...</p>}
+              {cargandoEquipos && <p className="text-xs text-gray-500 dark:text-gray-400">Cargando equipos...</p>}
               {!cargandoEquipos && errorEquipos && (
-                <p className="text-xs text-red-600">{errorEquipos}</p>
+                <p className="text-xs text-red-600 dark:text-red-300">{errorEquipos}</p>
               )}
             </div>
           )}
 
           {errorLocal && (
-            <div className="rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            <div className="rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-500/40 dark:bg-red-500/10 dark:text-red-200">
               {errorLocal}
             </div>
           )}
 
-          <div className="flex flex-col gap-3 border-t border-gray-100 pt-4 sm:flex-row sm:items-center sm:justify-between">
-            <p className="text-sm text-gray-500">
+          <div className="flex flex-col gap-3 border-t border-gray-100 pt-4 sm:flex-row sm:items-center sm:justify-between dark:border-gray-800">
+            <p className="text-sm text-gray-500 dark:text-gray-400">
               {tipoDerivado === "evento"
                 ? "El registro se añadirá como evento con horario."
                 : tipoDerivado === "tarea_grupal"
@@ -429,7 +429,7 @@ const CrearEventoModal = ({ open, onClose, onCreated, onError }: CrearEventoModa
             <div className="flex gap-2">
               <button
                 type="button"
-                className="rounded-2xl border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-600 hover:bg-gray-50"
+                className="rounded-2xl border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-600 transition hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800/80"
                 onClick={onClose}
                 disabled={enviando}
               >
@@ -437,7 +437,7 @@ const CrearEventoModal = ({ open, onClose, onCreated, onError }: CrearEventoModa
               </button>
               <button
                 type="submit"
-                className="rounded-2xl bg-blue-600 px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-blue-300"
+                className="rounded-2xl bg-blue-600 px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-blue-300 dark:bg-blue-500 dark:hover:bg-blue-400"
                 disabled={enviando}
               >
                 {enviando ? "Guardando..." : "Guardar"}

--- a/frontend/components/Sidebar.tsx
+++ b/frontend/components/Sidebar.tsx
@@ -41,12 +41,12 @@ export default function Sidebar() {
           );
         })}
       </nav>
-      <div className="mt-6 rounded-xl border border-indigo-100 bg-indigo-50/60 p-4 text-xs text-indigo-900 transition dark:border-white/10 dark:bg-white/5 dark:text-gray-200">
-        <p className="font-semibold text-indigo-700 dark:text-white">Sincroniza tu agenda</p>
-        <p className="mt-1 text-indigo-600 dark:text-gray-300">
+      <div className="mt-6 rounded-xl border border-indigo-100 bg-indigo-50/60 p-4 text-xs text-indigo-900 transition dark:border-indigo-500/30 dark:bg-indigo-500/10 dark:text-gray-100">
+        <p className="font-semibold text-indigo-700 dark:text-indigo-200">Sincroniza tu agenda</p>
+        <p className="mt-1 text-indigo-600 dark:text-indigo-200/90">
           Conecta tus cuentas para mantener tus eventos siempre actualizados.
         </p>
-        <button className="mt-4 inline-flex items-center justify-center rounded-lg bg-indigo-500 px-3 py-2 text-xs font-semibold text-white transition hover:bg-indigo-400">
+        <button className="mt-4 inline-flex items-center justify-center rounded-lg bg-indigo-500 px-3 py-2 text-xs font-semibold text-white transition hover:bg-indigo-400 dark:bg-indigo-500 dark:hover:bg-indigo-400">
           Conectar ahora
         </button>
       </div>

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -2,18 +2,28 @@
 @tailwind components;
 @tailwind utilities;
 
-html,
-body {
-  min-height: 100%;
-  scroll-behavior: smooth;
-}
+@layer base {
+  html,
+  body {
+    min-height: 100%;
+    scroll-behavior: smooth;
+  }
 
-body {
-  @apply bg-gray-50 text-gray-900 transition-colors duration-300;
-}
+  :root {
+    color-scheme: light;
+  }
 
-.dark body {
-  @apply bg-gray-950 text-gray-100;
+  body {
+    @apply min-h-full bg-gray-50 text-gray-900 antialiased transition-colors duration-300;
+  }
+
+  .dark :root {
+    color-scheme: dark;
+  }
+
+  .dark body {
+    @apply bg-gray-950 text-gray-100;
+  }
 }
 
 ::selection {


### PR DESCRIPTION
## Summary
- ensure global base styles set body colors for both light and dark themes
- update panel layouts, dashboard pages, and modal components with dark mode friendly backgrounds and text colors
- refresh sidebar callout styling for consistent appearance across themes

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916bcd696388327901075ff4b5989db)