### PR TITLE
Remove sync card and improve calendar dark mode

### DIFF
--- a/frontend/components/Sidebar.tsx
+++ b/frontend/components/Sidebar.tsx
@@ -41,15 +41,6 @@ export default function Sidebar() {
           );
         })}
       </nav>
-      <div className="mt-6 rounded-xl border border-indigo-100 bg-indigo-50/60 p-4 text-xs text-indigo-900 transition dark:border-indigo-500/30 dark:bg-indigo-500/10 dark:text-gray-100">
-        <p className="font-semibold text-indigo-700 dark:text-indigo-200">Sincroniza tu agenda</p>
-        <p className="mt-1 text-indigo-600 dark:text-indigo-200/90">
-          Conecta tus cuentas para mantener tus eventos siempre actualizados.
-        </p>
-        <button className="mt-4 inline-flex items-center justify-center rounded-lg bg-indigo-500 px-3 py-2 text-xs font-semibold text-white transition hover:bg-indigo-400 dark:bg-indigo-500 dark:hover:bg-indigo-400">
-          Conectar ahora
-        </button>
-      </div>
     </aside>
   );
 }

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -39,3 +39,27 @@ a {
 button {
   outline: none;
 }
+
+.dark .fc {
+  --fc-border-color: rgba(255, 255, 255, 0.1);
+}
+
+.dark .fc .fc-col-header,
+.dark .fc .fc-col-header-cell {
+  background-color: rgba(255, 255, 255, 0.03);
+}
+
+.dark .fc .fc-col-header-cell-cushion {
+  color: #cbd5e1;
+  font-weight: 600;
+}
+
+.dark .fc .fc-daygrid-day-number {
+  color: #cbd5e1;
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+.dark .fc .fc-daygrid-day {
+  border-color: rgba(255, 255, 255, 0.1);
+}


### PR DESCRIPTION
## Summary
- remove the "Sincroniza tu agenda" sidebar card from the panel layout
- tweak FullCalendar dark theme colors so headers and day numbers remain legible

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691788c0760083278f2862480aecd576)