### PR TITLE
Fix /api/events response and event query

### DIFF
--- a/frontend/app/api/events/route.ts
+++ b/frontend/app/api/events/route.ts
@@ -19,10 +19,12 @@ interface EventoInternoRow {
   inicio: string;
   fin: string;
   tipo: string;
+  ubicacion: string | null;
   equipo_nombre: string | null;
   estado_asistencia: "pendiente" | "aceptado" | "rechazado" | null;
   es_organizador: 0 | 1;
-  estado_evento: EstadoEvento | null;
+  es_participante: 0 | 1;
+  estado_evento: EstadoEvento;
   creador_nombre: string | null;
 }
 
@@ -60,12 +62,18 @@ interface EventoUnificado {
   inicio: string | null;
   fin: string | null;
   fecha: string | null;
+  ubicacion: string | null;
   idEquipo: number | null;
   alcance: Alcance;
   equipoNombre: string | null;
   estadoAsistencia: "pendiente" | "aceptado" | "rechazado" | null;
   esOrganizador: boolean;
+  esParticipante?: boolean;
+  es_participante?: boolean;
   estadoEvento?: EstadoEvento;
+  estado_evento?: EstadoEvento;
+  creadorNombre?: string | null;
+  creador_nombre?: string | null;
 }
 
 async function obtenerUsuarioAutenticado(): Promise<number | null> {
@@ -277,10 +285,12 @@ export async function GET() {
          e.inicio,
          e.fin,
          e.tipo,
+         e.ubicacion,
          eq.nombre AS equipo_nombre,
          pei.estado_asistencia,
          CASE WHEN e.id_usuario = ? THEN 1 ELSE 0 END AS es_organizador,
-         e.estado AS estado_evento,
+         CASE WHEN pei.id IS NOT NULL THEN 1 ELSE 0 END AS es_participante,
+         'confirmado' AS estado_evento,
          creador.nombre AS creador_nombre
        FROM eventos_internos e
        LEFT JOIN participantes_evento_interno pei
@@ -292,29 +302,37 @@ export async function GET() {
       [userId, userId, userId]
     );
 
-    const eventosUnificados: EventoUnificado[] = eventos.map((evento) => ({
-      id: `evento-${evento.id}`,
-      source: "evento_interno",
-      sourceId: evento.id,
-      tipo: "evento",
-      titulo: evento.titulo,
-      descripcion: evento.descripcion ?? null,
-      inicio: evento.inicio,
-      fin: evento.fin,
-      fecha: null,
-      idEquipo: evento.id_equipo,
-      alcance: evento.id_equipo ? "equipo" : "personal",
-      equipoNombre: evento.equipo_nombre ?? null,
-      estadoAsistencia:
-        evento.es_organizador === 1
-          ? "aceptado"
-          : evento.estado_asistencia ?? "pendiente",
-      esOrganizador: evento.es_organizador === 1,
-      estadoEvento: evento.estado_evento ?? "confirmado",
-      estado_evento: evento.estado_evento ?? "confirmado",
-      creadorNombre: evento.creador_nombre ?? null,
-      creador_nombre: evento.creador_nombre ?? null,
-    }));
+    const eventosUnificados: EventoUnificado[] = eventos.map((evento) => {
+      const esParticipante =
+        evento.es_organizador === 1 || evento.es_participante === 1;
+
+      return {
+        id: `evento-${evento.id}`,
+        source: "evento_interno",
+        sourceId: evento.id,
+        tipo: "evento",
+        titulo: evento.titulo,
+        descripcion: evento.descripcion ?? null,
+        inicio: evento.inicio,
+        fin: evento.fin,
+        fecha: null,
+        ubicacion: evento.ubicacion ?? null,
+        idEquipo: evento.id_equipo,
+        alcance: evento.id_equipo ? "equipo" : "personal",
+        equipoNombre: evento.equipo_nombre ?? null,
+        estadoAsistencia:
+          evento.es_organizador === 1
+            ? "aceptado"
+            : evento.estado_asistencia ?? "pendiente",
+        esOrganizador: evento.es_organizador === 1,
+        esParticipante,
+        es_participante: esParticipante,
+        estadoEvento: evento.estado_evento ?? "confirmado",
+        estado_evento: evento.estado_evento ?? "confirmado",
+        creadorNombre: evento.creador_nombre ?? null,
+        creador_nombre: evento.creador_nombre ?? null,
+      };
+    });
 
     const tareas = await allQuery<TareaRow>(
       `SELECT
@@ -352,11 +370,16 @@ export async function GET() {
         inicio: null,
         fin: null,
         fecha: tarea.fecha,
+        ubicacion: null,
         idEquipo: tarea.id_equipo,
         alcance,
         equipoNombre: tarea.equipo_nombre ?? null,
         estadoAsistencia: null,
         esOrganizador: tarea.id_usuario === userId,
+        esParticipante: tarea.id_usuario === userId,
+        es_participante: tarea.id_usuario === userId,
+        creadorNombre: null,
+        creador_nombre: null,
       };
     });
 
@@ -364,7 +387,7 @@ export async function GET() {
       (a, b) => obtenerFechaOrden(a) - obtenerFechaOrden(b)
     );
 
-    return NextResponse.json(combinados);
+    return NextResponse.json({ eventos: combinados });
   } catch (error) {
     console.error("[GET /api/events]", error);
     return NextResponse.json(


### PR DESCRIPTION
## Summary
- update the events API query to avoid selecting a non-existent status column and include participant and location metadata
- normalize the unified event payload so it always includes optional fields expected by the dashboard and wrap the response under the `eventos` key

## Testing
- npm run lint *(fails: Invalid project directory provided, no such directory: /workspace/agenda-inteligente/frontend/lint)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691789f9dcf8832786e0b405002e4a49)