### PR TITLE
Add PWA support and Capacitor/Tauri wrappers

### DIFF
--- a/.env.multiplatform.example
+++ b/.env.multiplatform.example
@@ -1,0 +1,10 @@
+# URL base de la aplicación web Next.js
+WEB_BASE_URL=http://localhost:3000
+
+# URL que debe cargar la app móvil (Capacitor).
+# En desarrollo utiliza la IP LAN donde se ejecute `npm run dev` dentro de frontend.
+MOBILE_SERVER_URL=http://localhost:3000
+
+# URL que abrirá la aplicación de escritorio (Tauri).
+# Ajusta este valor a tu dominio público en producción.
+DESKTOP_SERVER_URL=http://localhost:3000

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ backups/
 # Environment files
 .env
 .env.*
+!.env.multiplatform.example
 .env.local
 frontend/.env
 frontend/.env.*

--- a/README.md
+++ b/README.md
@@ -100,3 +100,54 @@ Content-Type: application/json
 
 { "error": "No autenticado" }
 ```
+
+## Multiplataforma
+
+### PWA (Next.js)
+1. Instala dependencias y levanta el frontend:
+   ```bash
+   cd frontend
+   npm install
+   npm run dev
+   ```
+2. Verifica que `http://localhost:3000/manifest.json` responde correctamente.
+3. Abre las DevTools del navegador (Application → Service Workers) y confirma que `sw.js` se registre en producción. En desarrollo puedes forzarlo ejecutando un build (`npm run build && npm run start`).
+4. Ejecuta Lighthouse y comprueba que detecta la aplicación como instalable.
+5. Sustituye los iconos de `frontend/public/icons/` por imágenes reales en formato PNG para los tamaños indicados (192px y 512px como mínimo).
+
+### Aplicación móvil (Capacitor)
+Consulta la guía detallada en [`mobile/README.md`](mobile/README.md). Resumen rápido:
+1. Copia `.env.multiplatform.example` a `.env` y ajusta `MOBILE_SERVER_URL`.
+2. Desde `mobile/`, instala dependencias con `npm install`.
+3. Sincroniza plataformas con `npm run sync`.
+4. Añade Android/iOS (`npx cap add android` / `npx cap add ios`) y abre cada proyecto (`npm run android` / `npm run ios`).
+5. Comprueba que la aplicación abre la web remota y funciona el inicio de sesión.
+
+### Aplicación de escritorio (Tauri)
+Consulta [`desktop/README.md`](desktop/README.md). Resumen:
+1. Configura `DESKTOP_SERVER_URL` en tu `.env`.
+2. Desde `desktop/`, instala dependencias con `npm install`.
+3. Ejecuta `npm run dev` para abrir la ventana que carga la web remota.
+4. Utiliza `npm run build` para generar binarios de distribución.
+
+## Resumen de cambios multiplataforma
+- **PWA**: `frontend/public/manifest.json`, `frontend/public/sw.js`, `frontend/app/layout.tsx`, `frontend/components/ServiceWorkerRegistrar.tsx`.
+- **Mobile (Capacitor)**: carpeta `mobile/` con `package.json`, `capacitor.config.ts`, `tsconfig.json` y documentación.
+- **Desktop (Tauri)**: carpeta `desktop/` con configuración de Tauri (`src-tauri/`), `package.json`, `README.md` y placeholder de frontend.
+- **Configuración común**: archivo `.env.multiplatform.example` en la raíz para centralizar URLs.
+
+## Cómo probar todo
+1. **Web PWA**:
+   - `cd frontend && npm run dev`.
+   - Visita `http://localhost:3000/manifest.json` y comprueba que Lighthouse reconoce la PWA.
+   - En producción (`npm run build && npm run start`), revisa en DevTools que el service worker esté activo.
+2. **Mobile**:
+   - `cd mobile && npm install`.
+   - Ajusta `MOBILE_SERVER_URL` para apuntar al backend remoto (LAN o dominio).
+   - `npm run sync`, luego `npx cap add android` / `npx cap add ios` y abre cada IDE con `npm run android` / `npm run ios`.
+   - Comprueba que la app carga la web y que las operaciones básicas (login, eventos) funcionan.
+3. **Desktop**:
+   - `cd desktop && npm install`.
+   - Configura `DESKTOP_SERVER_URL` (por ejemplo `http://localhost:3000`).
+   - `npm run dev` para ejecutar en modo desarrollo o `npm run build` para generar binarios.
+   - Confirma que la ventana abre la web de Agenda Inteligente y mantiene el flujo de trabajo.

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -1,0 +1,48 @@
+# Aplicación de escritorio con Tauri
+
+Este contenedor de escritorio utiliza **Tauri** para abrir la versión web remota de Agenda Inteligente.
+
+## Requisitos previos
+
+- Rust y cargo instalados (consulta <https://www.rust-lang.org/tools/install>).
+- Node.js 18+ y npm 9+.
+- El backend de Agenda Inteligente accesible desde la máquina local o un dominio público.
+
+## Preparación inicial
+
+1. Instala las dependencias de JavaScript:
+
+   ```bash
+   cd desktop
+   npm install
+   ```
+
+   > También puedes recrear el proyecto con `npm create tauri-app@latest` eligiendo una plantilla vacía y reemplazando la configuración con los archivos de esta carpeta.
+
+2. Configura la variable `DESKTOP_SERVER_URL` en tu `.env` (consulta `../.env.multiplatform.example`).
+   - En desarrollo apunta a `http://localhost:3000` mientras ejecutas `frontend`.
+   - En producción utiliza tu dominio HTTPS público.
+
+## Ejecución
+
+- Desarrollo:
+
+  ```bash
+  npm run dev
+  ```
+
+  Esto abrirá una ventana de Tauri que carga la URL definida en `DESKTOP_SERVER_URL`.
+
+- Construcción de binarios:
+
+  ```bash
+  npm run build
+  ```
+
+  Generará instaladores o ejecutables para la plataforma actual en `src-tauri/target/`.
+
+## Notas importantes
+
+- No se empaqueta ningún backend ni base de datos dentro de la aplicación. Todo el tráfico se dirige al backend remoto existente.
+- Asegúrate de permitir contenido remoto en `tauri.conf.json` si utilizas dominios externos (la configuración incluida ya lo hace).
+- Para depurar problemas de conexión, verifica la consola de desarrollador (Ctrl+Shift+I) en la ventana de Tauri y la disponibilidad del backend remoto.

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "agenda-inteligente-desktop",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Wrapper de escritorio Tauri para Agenda Inteligente",
+  "scripts": {
+    "dev": "tauri dev",
+    "build": "tauri build"
+  },
+  "devDependencies": {
+    "@tauri-apps/cli": "^1.5.9"
+  }
+}

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "agenda-inteligente-desktop"
+version = "0.1.0"
+edition = "2021"
+description = "Wrapper de escritorio para Agenda Inteligente"
+authors = ["Agenda Inteligente Team"]
+license = "MIT"
+
+[build-dependencies]
+tauri-build = { version = "1.5", features = [] }
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tauri = { version = "1.5", features = ["shell-open"] }

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -1,0 +1,7 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
+fn main() {
+  tauri::Builder::default()
+    .run(tauri::generate_context!())
+    .expect("error while running Agenda Inteligente desktop shell");
+}

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://schema.tauri.app/config/1",
+  "package": {
+    "productName": "Agenda Inteligente",
+    "version": "0.1.0"
+  },
+  "build": {
+    "beforeBuildCommand": "",
+    "beforeDevCommand": "",
+    "devPath": "$env/DESKTOP_SERVER_URL",
+    "distDir": "../src"
+  },
+  "tauri": {
+    "allowlist": {
+      "all": false,
+      "http": {
+        "all": true
+      },
+      "shell": {
+        "open": true
+      }
+    },
+    "bundle": {
+      "active": true,
+      "identifier": "com.agenda.inteligente.desktop"
+    },
+    "windows": [
+      {
+        "label": "main",
+        "title": "Agenda Inteligente",
+        "width": 1280,
+        "height": 720,
+        "resizable": true,
+        "url": "$env/DESKTOP_SERVER_URL"
+      }
+    ],
+    "security": {
+      "csp": null
+    }
+  }
+}

--- a/desktop/src/index.html
+++ b/desktop/src/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <title>Agenda Inteligente Desktop</title>
+  </head>
+  <body>
+    <p>
+      Esta carpeta solo contiene un placeholder. La ventana de Tauri debería cargar la URL remota indicada en
+      <code>DESKTOP_SERVER_URL</code>.
+    </p>
+  </body>
+</html>

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter } from "next/font/google";
 import type { ReactNode } from "react";
 import "../styles/globals.css";
 import "../styles/theme.css";
+import ServiceWorkerRegistrar from "../components/ServiceWorkerRegistrar";
 
 // Inicializamos la fuente Inter para tener una tipografía consistente en toda la aplicación.
 const inter = Inter({ subsets: ["latin"], display: "swap" });
@@ -11,6 +12,8 @@ const inter = Inter({ subsets: ["latin"], display: "swap" });
 export const metadata: Metadata = {
   title: "Agenda Inteligente",
   description: "Dashboard principal de Agenda Inteligente",
+  manifest: "/manifest.json",
+  themeColor: "#0f172a",
 };
 
 // Este layout raíz solo envuelve la aplicación con las etiquetas <html> y <body>.
@@ -30,6 +33,7 @@ export default function RootLayout({
       >
         {/* Renderizamos el contenido específico de cada página o layout anidado. */}
         {children}
+        <ServiceWorkerRegistrar />
       </body>
     </html>
   );

--- a/frontend/components/ServiceWorkerRegistrar.tsx
+++ b/frontend/components/ServiceWorkerRegistrar.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect } from "react";
+
+export function ServiceWorkerRegistrar() {
+  useEffect(() => {
+    if (
+      typeof window === "undefined" ||
+      !("serviceWorker" in navigator) ||
+      process.env.NODE_ENV !== "production"
+    ) {
+      return;
+    }
+
+    navigator.serviceWorker
+      .register("/sw.js")
+      .catch((error) => {
+        console.error("Error al registrar el service worker:", error);
+      });
+  }, []);
+
+  return null;
+}
+
+export default ServiceWorkerRegistrar;

--- a/frontend/public/icons/README.md
+++ b/frontend/public/icons/README.md
@@ -1,0 +1,7 @@
+Sube aquí los iconos PNG de la PWA.
+
+Recomendados:
+- `icon-192.png`
+- `icon-512.png`
+
+Asegúrate de mantener los nombres utilizados en `manifest.json`.

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,0 +1,23 @@
+{
+  "name": "Agenda Inteligente",
+  "short_name": "Agenda",
+  "description": "Aplicación web de Agenda Inteligente",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "orientation": "any",
+  "background_color": "#0f172a",
+  "theme_color": "#0f172a",
+  "icons": [
+    {
+      "src": "/icons/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/icons/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,0 +1,76 @@
+const CACHE_NAME = "agenda-inteligente-cache-v1";
+const STATIC_ASSETS = [
+  "/manifest.json",
+  "/icons/icon-192.png",
+  "/icons/icon-512.png"
+];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => {
+      return cache.addAll(STATIC_ASSETS);
+    })
+  );
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches.keys().then((cacheNames) =>
+      Promise.all(
+        cacheNames
+          .filter((cacheName) => cacheName !== CACHE_NAME)
+          .map((cacheName) => caches.delete(cacheName))
+      )
+    )
+  );
+});
+
+self.addEventListener("fetch", (event) => {
+  const { request } = event;
+  const url = new URL(request.url);
+
+  if (
+    request.method !== "GET" ||
+    url.origin !== self.location.origin
+  ) {
+    return;
+  }
+
+  if (
+    url.pathname.startsWith("/_next/static/") ||
+    url.pathname.startsWith("/icons/") ||
+    STATIC_ASSETS.includes(url.pathname)
+  ) {
+    event.respondWith(
+      caches.match(request).then((cachedResponse) => {
+        if (cachedResponse) {
+          return cachedResponse;
+        }
+
+        return fetch(request).then((networkResponse) => {
+          const responseClone = networkResponse.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(request, responseClone));
+          return networkResponse;
+        });
+      })
+    );
+    return;
+  }
+
+  if (url.pathname.startsWith("/api/")) {
+    event.respondWith(
+      fetch(request).catch(() => caches.match(request))
+    );
+    return;
+  }
+
+  event.respondWith(
+    fetch(request)
+      .then((networkResponse) => {
+        const responseClone = networkResponse.clone();
+        caches.open(CACHE_NAME).then((cache) => cache.put(request, responseClone));
+        return networkResponse;
+      })
+      .catch(() => caches.match(request))
+  );
+});

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,0 +1,63 @@
+# Aplicación móvil con Capacitor
+
+Este wrapper móvil carga la versión web hospedada de **Agenda Inteligente** dentro de un WebView utilizando Capacitor.
+
+## Requisitos previos
+
+- Node.js 18 o superior.
+- npm 9 o superior.
+- Android Studio (para Android) y Xcode (para iOS) instalados según la plataforma que quieras probar.
+- Un backend de Agenda Inteligente corriendo de forma remota o accesible en la red local.
+
+## Preparación del proyecto
+
+1. Instala las dependencias dentro de la carpeta `mobile/`:
+
+   ```bash
+   cd mobile
+   npm install
+   ```
+
+   > Si prefieres recrear el proyecto desde cero, ejecuta `npm create @capacitor/app@latest` y selecciona la plantilla en blanco.
+
+2. Configura la URL del backend remoto editando la variable `MOBILE_SERVER_URL` en el archivo `.env` (consulta `../.env.multiplatform.example`).
+   - En desarrollo, apunta a la IP local donde corra `frontend` (por ejemplo `http://192.168.1.20:3000`).
+   - En producción, usa tu dominio público (`https://agenda.midominio.com`).
+
+3. Sincroniza las plataformas nativas después de cualquier cambio de configuración:
+
+   ```bash
+   npm run sync
+   # o directamente
+   npx cap sync
+   ```
+
+## Añadir plataformas
+
+- Android:
+
+  ```bash
+  npx cap add android
+  npm run android
+  ```
+
+- iOS:
+
+  ```bash
+  npx cap add ios
+  npm run ios
+  ```
+
+Cada comando `open` lanzará el proyecto en Android Studio o Xcode para que puedas compilar y ejecutar.
+
+## Comportamiento
+
+- La app **no** incluye ningún backend ni base de datos local. Todo el contenido se sirve desde la URL definida en `capacitor.config.ts`.
+- Las llamadas a `/api/...` siguen funcionando porque la web renderizada dentro del WebView se comunica con el backend remoto existente.
+- Si cambias la URL del servidor, vuelve a ejecutar `npm run sync` para propagar la configuración a los proyectos nativos.
+
+## Lanzamiento
+
+1. Asegúrate de tener el backend (`frontend/`) accesible en la red.
+2. Construye o abre la plataforma deseada desde Android Studio o Xcode.
+3. Comprueba que la aplicación abre la interfaz de Agenda Inteligente y que puedes iniciar sesión y gestionar eventos.

--- a/mobile/capacitor.config.ts
+++ b/mobile/capacitor.config.ts
@@ -1,0 +1,18 @@
+import type { CapacitorConfig } from "@capacitor/cli";
+
+// Esta configuración solo abre la versión web hospedada de Agenda Inteligente.
+// No se incluye backend ni base de datos dentro de la app móvil.
+const config: CapacitorConfig = {
+  appId: "com.agenda.inteligente",
+  appName: "Agenda Inteligente",
+  bundledWebRuntime: false,
+  webDir: "public",
+  server: {
+    // En desarrollo apunta a tu LAN (por ejemplo http://192.168.1.20:3000).
+    // En producción define MOBILE_SERVER_URL con tu dominio HTTPS.
+    url: process.env.MOBILE_SERVER_URL ?? "http://localhost:3000",
+    cleartext: true
+  }
+};
+
+export default config;

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "agenda-inteligente-mobile",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Wrapper móvil con Capacitor para Agenda Inteligente",
+  "scripts": {
+    "sync": "npx cap sync",
+    "android": "npx cap open android",
+    "ios": "npx cap open ios"
+  },
+  "dependencies": {
+    "@capacitor/android": "^5.7.0",
+    "@capacitor/app": "^5.0.6",
+    "@capacitor/core": "^5.7.0",
+    "@capacitor/ios": "^5.7.0",
+    "@capacitor/preferences": "^5.0.6"
+  },
+  "devDependencies": {
+    "@capacitor/cli": "^5.7.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["capacitor.config.ts"]
+}


### PR DESCRIPTION
## Summary
- add a web app manifest, service worker, and global registration for the Next.js PWA shell
- scaffold the Capacitor mobile wrapper that targets the hosted Agenda Inteligente frontend
- scaffold the Tauri desktop wrapper and shared multiplatform environment variable template

## Testing
- not run (not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69179d9f05188327a7cc981365e6f6f0)