### PR TITLE
Make panel sidebar responsive

### DIFF
--- a/frontend/app/(panel)/PanelLayoutClient.tsx
+++ b/frontend/app/(panel)/PanelLayoutClient.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useState } from "react";
+
+import Sidebar from "../../components/Sidebar";
+import { ThemeProvider } from "@/components/ThemeProvider";
+import type { ThemePreference } from "@/components/ThemeProvider";
+
+interface PanelLayoutClientProps {
+  children: ReactNode;
+  initialThemePreference: ThemePreference | null | undefined;
+}
+
+export default function PanelLayoutClient({
+  children,
+  initialThemePreference,
+}: PanelLayoutClientProps) {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  const toggleSidebar = () => setSidebarOpen((prev) => !prev);
+  const closeSidebar = () => setSidebarOpen(false);
+
+  return (
+    <ThemeProvider initialPreference={initialThemePreference ?? undefined}>
+      <div className="relative flex min-h-screen w-full bg-gray-50 text-gray-900 transition-colors duration-300 dark:bg-gray-950 dark:text-gray-100">
+        {sidebarOpen && (
+          <div
+            className="fixed inset-0 z-30 bg-black/50 md:hidden"
+            onClick={closeSidebar}
+            aria-hidden="true"
+          />
+        )}
+
+        <Sidebar isOpen={sidebarOpen} onNavigate={closeSidebar} />
+
+        <div className="flex min-h-screen flex-1 flex-col md:ml-64">
+          <header className="flex items-center gap-3 border-b border-gray-200 bg-white px-4 py-3 shadow-sm dark:border-gray-800 dark:bg-gray-900 md:hidden">
+            <button
+              type="button"
+              onClick={toggleSidebar}
+              className="rounded-md p-2 text-2xl text-gray-700 transition hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:text-gray-200 dark:hover:bg-gray-800"
+              aria-label={sidebarOpen ? "Cerrar menú" : "Abrir menú"}
+              aria-expanded={sidebarOpen}
+              aria-controls="panel-sidebar"
+            >
+              ☰
+            </button>
+          </header>
+
+          <main className="flex flex-1 flex-col p-6">{children}</main>
+        </div>
+      </div>
+    </ThemeProvider>
+  );
+}
+

--- a/frontend/app/(panel)/layout.tsx
+++ b/frontend/app/(panel)/layout.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from "react";
-import Sidebar from "../../components/Sidebar";
-import { ThemeProvider } from "@/components/ThemeProvider";
+import PanelLayoutClient from "./PanelLayoutClient";
 import { getUserFromSession } from "@/lib/auth";
 
 /**
@@ -17,18 +16,8 @@ export default async function PanelLayout({
   const user = await getUserFromSession();
 
   return (
-    <ThemeProvider initialPreference={user?.tema_preferencia ?? "auto"}>
-      <div className="flex min-h-screen w-full bg-gray-50 text-gray-900 transition-colors duration-300 dark:bg-gray-950 dark:text-gray-100">
-        {/* Sidebar lateral */}
-        <Sidebar />
-
-        {/* Contenedor principal */}
-        <main className="flex flex-1 flex-col p-6 md:ml-64">
-          {/* Header temporalmente deshabilitado */}
-          {/* <Header /> */}
-          {children}
-        </main>
-      </div>
-    </ThemeProvider>
+    <PanelLayoutClient initialThemePreference={user?.tema_preferencia ?? "auto"}>
+      {children}
+    </PanelLayoutClient>
   );
 }

--- a/frontend/components/Sidebar.tsx
+++ b/frontend/components/Sidebar.tsx
@@ -11,24 +11,35 @@ const navigation = [
   { name: "Configuración", href: "/configuracion", icon: "⚙️" },
 ];
 
-export default function Sidebar() {
+interface SidebarProps {
+  isOpen: boolean;
+  onNavigate?: () => void;
+}
+
+export default function Sidebar({ isOpen, onNavigate }: SidebarProps) {
   const pathname = usePathname();
 
   return (
-    <aside className="fixed inset-y-0 left-0 z-40 hidden w-64 flex-col border-r border-gray-200 bg-white p-6 text-gray-700 shadow-xl transition-colors duration-300 dark:border-gray-800 dark:bg-gray-900 dark:text-gray-100 md:flex">
+    <aside
+      id="panel-sidebar"
+      className={`fixed top-0 left-0 z-40 flex h-screen w-64 flex-col border-r border-gray-200 bg-white p-6 text-gray-700 shadow-xl transition-transform duration-300 ease-in-out dark:border-gray-800 dark:bg-gray-900 dark:text-gray-100 md:translate-x-0 md:shadow-none ${
+        isOpen ? "translate-x-0" : "-translate-x-full"
+      }`}
+    >
       <div className="mb-8">
         <span className="text-sm font-semibold uppercase tracking-widest text-indigo-500 dark:text-indigo-300">
           Agenda Inteligente
         </span>
         <h2 className="mt-2 text-2xl font-bold text-gray-900 dark:text-white">Panel</h2>
       </div>
-      <nav className="flex flex-1 flex-col gap-1 text-sm">
+      <nav className="flex flex-1 flex-col gap-1 text-sm" aria-label="Navegación principal">
         {navigation.map((item) => {
           const isActive = pathname === item.href || (item.href !== "/" && pathname.startsWith(item.href));
           return (
             <Link
               key={item.name}
               href={item.href}
+              onClick={onNavigate}
               className={`flex items-center gap-3 rounded-xl px-3 py-2 transition ${
                 isActive
                   ? "bg-indigo-50 text-indigo-600 dark:bg-indigo-500/20 dark:text-indigo-200"


### PR DESCRIPTION
## Summary
- add a client wrapper for the panel layout to handle responsive sidebar state and mobile header toggle
- update the sidebar component to support slide-in animations, navigation callbacks, and accessibility attributes
- ensure the theme preference from the session continues to power the panel UI while enabling an overlay backdrop on mobile

## Testing
- npm run lint *(fails: Invalid project directory provided, no such directory: /workspace/agenda-inteligente/frontend/lint)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917a7e24760832787027ebfcecfaee3)